### PR TITLE
Run method

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,7 @@ import miniflask
 # initialize miniflask
 mf = miniflask.init(module_dirs="./modules")
 mf.parse_args()
-
-# check if all requested modules are loaded
-if not mf.halt_parse:
-
-    # call event "main" if exists
-    if hasattr(mf.event, 'main'):
-        mf.event.main()
-    else:
-        print("There is nothing to do.")
+mf.run()
 ```
 
 

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -369,7 +369,7 @@ class miniflask():
             if hasattr(self.event, call):
                 getattr(self.event, call)()
             else:
-                print("No event '{0}' registered."
+                print("No event '{0}' registered. "
                       "Please make sure to register the event '{0}', "
                       "or provide a suitable event to call.".format(call))
 

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -362,6 +362,16 @@ class miniflask():
 
         print(highlight_blue_line("-"*50))
 
+    def run(self, call="main"):
+        # check if all requested modules are loaded
+        if not self.halt_parse:
+            # call event if exists
+            if hasattr(self.event, call):
+                getattr(self.event, call)()
+            else:
+                print("No event '{0}' registered."
+                      "Please make sure to register the event '{0}', "
+                      "or provide a suitable event to call.".format(call))
 
 
 class miniflask_wrapper(miniflask):


### PR DESCRIPTION
This PR adds a `miniflask.run(call='main')` method, which calls the given event, if it is registered.

Using miniflask looks now a little bit cleaner.
```python
mf = miniflask(...)
mf.parse_args()
mf.run()
```

Additionally, the name of the event to call is passed as an argument `call`, so that it is easy to switch and execute other events, thus the generic `getattr(self.event, call)()` line.