### PR TITLE
Required arguments without defaults.

### DIFF
--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -276,7 +276,12 @@ class miniflask():
         elif isinstance(val,list):
             self._settings_parser_add(varname, varname_short, val[0], nargs="+", default=val)
         else:
-            raise ValueError("Type '%s' not supported. (Used for setting '%s')" % (type(val),varname))
+            try:
+                self.settings_parser.add_argument("--"+varname, type=val, dest=varname, metavar=highlight_type("\t{}".format(val)))
+                if varname_short:
+                    self.settings_parser.add_argument("--"+varname_short, type=val, dest=varname, help=argparse_SUPPRESS)
+            except:
+                raise ValueError("Type '%s' not supported. (Used for setting '%s')" % (type(val), varname))
 
     # ======= #
     # runtime #

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -277,9 +277,9 @@ class miniflask():
             self._settings_parser_add(varname, varname_short, val[0], nargs="+", default=val)
         else:
             try:
-                self.settings_parser.add_argument("--"+varname, type=val, dest=varname, metavar=highlight_type("\t{}".format(val)))
+                self.settings_parser.add_argument("--"+varname, type=val, dest=varname, required=True, metavar=highlight_type("\t{}".format(val)))
                 if varname_short:
-                    self.settings_parser.add_argument("--"+varname_short, type=val, dest=varname, help=argparse_SUPPRESS)
+                    self.settings_parser.add_argument("--"+varname_short, type=val, dest=varname, required=True, help=argparse_SUPPRESS)
             except:
                 raise ValueError("Type '%s' not supported. (Used for setting '%s')" % (type(val), varname))
 


### PR DESCRIPTION
Currently, there is no way to declare a required argument, which needs to be set.
Sometimes, default values can only be guessed / are platform dependend, so this could be a desired feature.

A method like `miniflask.register_required(..)` would be nice, with the following usage:
```python
miniflask.register_required({
    "somestring": str,
    "someint": int,
    "somefloat": float,
})
```

Looking into the code I noticed a similar workaround can currently be used:
```python
miniflask.register_defaults({
    "somestring": str,
    "someint": int,
    "somefloat": float,
}, parsefn=False)
```
if one applies the changes of this PR.
Miniflask tries to use the argument value as type, if no instance is found before.
If the required arguments are not set, argparse will fail with the corresponding error:
```bash
error: the following arguments are required: --somestring, --someint, --somefloat
```

Is this a suitable approach?
Is this a dirty abuse of the `parsefn` flag, which will have unintended side effects?