### PR TITLE
Remove white coloring of 'value' text

### DIFF
--- a/src/miniflask/util.py
+++ b/src/miniflask/util.py
@@ -46,7 +46,7 @@ highlight_loaded_none = lambda x: fg('red')+x+attr('reset')
 highlight_loaded = lambda x, y: attr('underlined')+x+attr('reset')+" "+fg('green')+attr('bold')+", ".join(y)+attr('reset')
 highlight_event = lambda x: fg('light_yellow')+x+attr('reset')
 highlight_type = lambda x: fg('cyan')+x+attr('reset')
-highlight_val = lambda x: fg('white')+x+attr('reset')
+highlight_val = lambda x: x
 highlight_val_overwrite = lambda x: fg('red')+attr('bold')+x+attr('reset')
 
 


### PR DESCRIPTION
The white color often interferes with (dark) colorschemes that e.g. automatically invert colors. (I am not sure why the white color get's inverted to black and thus is not readable on dark background)

Here is the issue with a dark colorscheme terminal (in JetBrains PyCharm):

| issue | solved |
| --- | --- |
| ![miniflask_issue](https://user-images.githubusercontent.com/7113492/94686456-24c06e00-032b-11eb-8b9b-e198e6fcc197.png) | ![miniflask_issue_after](https://user-images.githubusercontent.com/7113492/94686703-7a951600-032b-11eb-9664-01341dd22297.png) |


This PR proposes to not highlight the text of `values` and therefire removes the white coloring.

Here is a quick comparison with a _default_ dark terminal:
| before | after |
| --- | --- |
| ![miniflask_before](https://user-images.githubusercontent.com/7113492/94686048-892efd80-032a-11eb-911b-fd5452ba80bd.png) | ![miniflask_after](https://user-images.githubusercontent.com/7113492/94686068-921fcf00-032a-11eb-9b1d-433bafaba6e7.png) |

Here is a quick comparison with a _default_ light terminal:
| before | after |
| --- | --- |
| ![miniflask_white_colorscheme_issue](https://user-images.githubusercontent.com/7113492/94687192-35251880-032c-11eb-8156-ff1b5e5887a5.png) | ![miniflask_white_colorscheme_solved](https://user-images.githubusercontent.com/7113492/94687184-2fc7ce00-032c-11eb-8524-2a177c51906c.png) |

I don't think we loose anything, but gain better portability.