### PR TITLE
CI Workflow: Syntax Check and Static Analysis Improvements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,3 +8,10 @@ exclude =
     venv,
     build,
     dist
+per-file-ignores =
+    # E731 do not assign a lambda expression, use a def
+    src/miniflask/util.py: E731
+    # E221 multiple spaces before operator
+    # F401 imported but unused
+    # F403 unable to detect undefined names
+    src/miniflask/__init__.py: E221,F401,F403

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+max-complexity = 10
+max-line-length = 127
+exclude =
+    .git,
+    __pycache__,
+    docs,
+    venv,
+    build,
+    dist

--- a/.github/workflows/linting-python.yml
+++ b/.github/workflows/linting-python.yml
@@ -17,6 +17,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip wheel
         python -m pip install flake8 pylint pytest
+        # install deps for pylint
+        python -m pip install colored
+        # build and install the package itself
+        python -m pip install .
     - name: Syntax Check
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/linting-python.yml
+++ b/.github/workflows/linting-python.yml
@@ -15,11 +15,14 @@ jobs:
         python-version: 3.x
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
-        pip install flake8
-    - name: Lint with flake8
+        python -m pip install --upgrade pip wheel
+        pip install flake8 pylint pytest
+    - name: Syntax Check
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Static Analysis
+      run: |
+        flake8 . --count --ignore E501 --statistics
+        pylint -d W0511 -d C0114 -d C0116 -d C0115 -d C0301 -d C0103 -d R0913 -d R0914 -d R0902 -d R0912 -d R0801 -d W0212 -d W0223 -d E1101 -d W0221 -d E1102 `find . -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`
+        pylint --exit-zero `find . -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`

--- a/.github/workflows/linting-python.yml
+++ b/.github/workflows/linting-python.yml
@@ -28,5 +28,9 @@ jobs:
     - name: Static Analysis
       run: |
         flake8 . --count --ignore E501 --statistics
+        pylint -d W0511 -d C0114 -d C0116 -d C0115 -d C0301 -d C0103 -d R0913 -d R0914 -d R0902 -d R0912 -d R0801 -d W0212 -d W0223 -d E1101 -d W0221 -d E1102 src/miniflask
+        pylint --exit-zero src/miniflask
+    - name: Static Analysis of Tests
+      run: |
         pylint -d W0511 -d C0114 -d C0116 -d C0115 -d C0301 -d C0103 -d R0913 -d R0914 -d R0902 -d R0912 -d R0801 -d W0212 -d W0223 -d E1101 -d W0221 -d E1102 `find . -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`
         pylint --exit-zero `find . -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`

--- a/.github/workflows/linting-python.yml
+++ b/.github/workflows/linting-python.yml
@@ -24,13 +24,18 @@ jobs:
     - name: Syntax Check
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: Static Analysis
       run: |
-        flake8 . --count --ignore E501 --statistics
+        flake8 src --count --ignore E501 --statistics
         pylint -d W0511 -d C0114 -d C0116 -d C0115 -d C0301 -d C0103 -d R0913 -d R0914 -d R0902 -d R0912 -d R0801 -d W0212 -d W0223 -d E1101 -d W0221 -d E1102 src/miniflask
         pylint --exit-zero src/miniflask
-    - name: Static Analysis of Tests
+    - name: Syntax Check of Tests
       run: |
-        pylint -d W0511 -d C0114 -d C0116 -d C0115 -d C0301 -d C0103 -d R0913 -d R0914 -d R0902 -d R0912 -d R0801 -d W0212 -d W0223 -d E1101 -d W0221 -d E1102 `find . -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`
-        pylint --exit-zero `find . -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 tests --count --select=E9,F63,F7,F82 --show-source --statistics
+    - name: Static Analysis of Tests (Modules)
+      run: |
+        flake8 tests --count --ignore E501 --statistics
+        pylint -d W0511 -d C0114 -d C0116 -d C0115 -d C0301 -d C0103 -d R0913 -d R0914 -d R0902 -d R0912 -d R0801 -d W0212 -d W0223 -d E1101 -d W0221 -d E1102 `find tests -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`
+        pylint --exit-zero `find tests -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`

--- a/.github/workflows/linting-python.yml
+++ b/.github/workflows/linting-python.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel
-        pip install flake8 pylint pytest
+        python -m pip install flake8 pylint pytest
     - name: Syntax Check
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/linting-python.yml
+++ b/.github/workflows/linting-python.yml
@@ -3,7 +3,7 @@ name: Linting Python
 on: [push]
 
 jobs:
-  linting:
+  Syntax-Check--Static-Analysis:
 
     runs-on: ubuntu-latest
 
@@ -23,6 +23,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: Static Analysis
       run: |
-        flake8 . --count --ignore E501 --statistics
+        flake8 . --count --ignore E501 --statistics --exit-zero
         pylint -d W0511 -d C0114 -d C0116 -d C0115 -d C0301 -d C0103 -d R0913 -d R0914 -d R0902 -d R0912 -d R0801 -d W0212 -d W0223 -d E1101 -d W0221 -d E1102 `find . -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`
         pylint --exit-zero `find . -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`

--- a/.github/workflows/linting-python.yml
+++ b/.github/workflows/linting-python.yml
@@ -27,6 +27,6 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
     - name: Static Analysis
       run: |
-        flake8 . --count --ignore E501 --statistics --exit-zero
+        flake8 . --count --ignore E501 --statistics
         pylint -d W0511 -d C0114 -d C0116 -d C0115 -d C0301 -d C0103 -d R0913 -d R0914 -d R0902 -d R0912 -d R0801 -d W0212 -d W0223 -d E1101 -d W0221 -d E1102 `find . -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`
         pylint --exit-zero `find . -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`


### PR DESCRIPTION
This PR updates the CI workflow for linting and splits jobs for the `src` and the `tests` folder.
In detail there are now the following jobs defined, which will run in the following order:

- **Syntax Check** for `src` using `flake8`
- **Static Analysis** for `src` using `flake8`
    - `flake8` for `src`
    - partially `pylint` for module `src/miniflask`
    - complete `pylint` for `src/miniflask` (allowed to fail)
- **Syntax Check** for `tests` using `flake8`
- **Static Analysis** for `tests` using `flake8`
    - `flake8` for `tests`
    - partially `pylint` for all miniflask modules (`.module`) in `tests`
    - complete `pylint` for all miniflask modules (`.module`) in `tests` (allowed to fail)

The previous workflow only implemented the *Syntax Check*, but no *Static Analysis*.