### PR TITLE
Fixing "simple" linting issues

### DIFF
--- a/src/miniflask/__init__.py
+++ b/src/miniflask/__init__.py
@@ -16,4 +16,3 @@ __tracker__       = __url__ + '/issues'
 __author__        = "David Hartmann"
 __license__       = "MIT License"
 __copyright__     = "Copyright (c) 2020 " + __author__
-

--- a/src/miniflask/dummy.py
+++ b/src/miniflask/dummy.py
@@ -13,17 +13,17 @@ class miniflask_dummy():
             self.event = miniflask_dummy(with_child=False)
 
     def getEvents(self):
-        return list(zip(self.event_objs.keys(),self.event_objs.values()))
+        return list(zip(self.event_objs.keys(), self.event_objs.values()))
 
     def register_event(self, name, fn, unique=False, call_before_after=True):
-        self.event_objs[name] = (unique,fn)
+        self.event_objs[name] = (unique, fn)
 
-    def register_defaults(self,*args, **kwargs):
+    def register_defaults(self, *args, **kwargs):
         pass
 
     # ignore all other function calls
     def __getattr__(self, name):
-        if name in ["event","modules_avail","modules_loaded","register_event","register_defaults"]:
+        if name in ["event", "modules_avail", "modules_loaded", "register_event", "register_defaults"]:
             return super().__getattribute__(name)
         return dummy_fn
     # def load(self,*args):

--- a/src/miniflask/dummy.py
+++ b/src/miniflask/dummy.py
@@ -3,6 +3,7 @@ def dummy_fn(*args, altfn=None, **kwargs):
         return altfn(*args, **kwargs)
     return []
 
+
 class miniflask_dummy():
     def __init__(self, *args, with_child=True, **kwargs):
         self.event_objs = {}
@@ -29,5 +30,3 @@ class miniflask_dummy():
     #     pass
     # def showModules(self,*args):
     #     pass
-
-

--- a/src/miniflask/event.py
+++ b/src/miniflask/event.py
@@ -1,7 +1,9 @@
 import inspect
 
+
 class outervar():
     pass
+
 
 class event_obj():
     def __init__(self, fn, unique, module, call_before_after=True):
@@ -13,6 +15,7 @@ class event_obj():
         else:
             self.fn = [fn]
             self.modules = [module]
+
 
 class event(dict):
     def __init__(self, mf, optional=False):
@@ -158,5 +161,3 @@ class event(dict):
 
         setattr(self, name, fn_wrap)
         return fn_wrap
-
-

--- a/src/miniflask/event.py
+++ b/src/miniflask/event.py
@@ -148,7 +148,8 @@ class event(dict):
                     setattr(fn_wrap, 'fns', [fn_wrap])
             else:
                 def multiple_fn_wrap_scope(orig_fns, modules=eobj.modules):
-                    fns, have_signature = zip(*[fn_wrap_scope(fn, state=module.state, event=module.event, module=module, skip_twice=True) for fn, module in zip(orig_fns,modules)])
+                    fns, have_signature = zip(*[fn_wrap_scope(fn, state=module.state, event=module.event, module=module, skip_twice=True) for fn, module in zip(orig_fns, modules)])
+
                     def fn_wrap(*args, altfn=None, **kwargs):
                         results = []
                         for i, fn in enumerate(fns):

--- a/src/miniflask/event.py
+++ b/src/miniflask/event.py
@@ -26,11 +26,11 @@ class event(dict):
     def make_dummy_fn(self, name, call_before_after=True):
         # automatic before/after events
         name_before = 'before_' + name
-        name_after  = 'after_' + name
-        has_before  = name_before in self._mf.event_objs and call_before_after
-        has_after   = name_after in self._mf.event_objs and call_before_after
-        fn_after    = getattr(self._mf.event, name_after) if has_after else None
-        fn_before   = getattr(self._mf.event, name_before) if has_before else None
+        name_after = 'after_' + name
+        has_before = name_before in self._mf.event_objs and call_before_after
+        has_after = name_after in self._mf.event_objs and call_before_after
+        fn_after = getattr(self._mf.event, name_after) if has_after else None
+        fn_before = getattr(self._mf.event, name_before) if has_before else None
 
         def dummy_fn(*args, altfn=None, **kwargs):
             if callable(altfn):
@@ -46,7 +46,7 @@ class event(dict):
 
         return dummy_fn
 
-    def __getattr__(self, name):
+    def __getattr__(self, name):  # noqa: C901 too-complex
 
         if name not in self._mf.event_objs:
             if not self.optional_value:
@@ -84,11 +84,11 @@ class event(dict):
 
                 # automatic before/after events
                 name_before = 'before_' + name
-                name_after  = 'after_' + name
-                has_before  = name_before in self._mf.event_objs and call_before_after
-                has_after   = name_after in self._mf.event_objs and call_before_after
-                fn_after    = getattr(self._mf.event, name_after) if has_after else None
-                fn_before   = getattr(self._mf.event, name_before) if has_before else None
+                name_after = 'after_' + name
+                has_before = name_before in self._mf.event_objs and call_before_after
+                has_after = name_after in self._mf.event_objs and call_before_after
+                fn_after = getattr(self._mf.event, name_after) if has_after else None
+                fn_before = getattr(self._mf.event, name_before) if has_before else None
 
                 # get index of "state" / "event"
                 if len(arg_names) > 0:

--- a/src/miniflask/event.py
+++ b/src/miniflask/event.py
@@ -25,8 +25,8 @@ class event(dict):
 
     def make_dummy_fn(self, name, call_before_after=True):
         # automatic before/after events
-        name_before = 'before_'+name
-        name_after  = 'after_'+name
+        name_before = 'before_' + name
+        name_after  = 'after_' + name
         has_before  = name_before in self._mf.event_objs and call_before_after
         has_after   = name_after in self._mf.event_objs and call_before_after
         fn_after    = getattr(self._mf.event, name_after) if has_after else None
@@ -83,8 +83,8 @@ class event(dict):
                     has_signature = False
 
                 # automatic before/after events
-                name_before = 'before_'+name
-                name_after  = 'after_'+name
+                name_before = 'before_' + name
+                name_after  = 'after_' + name
                 has_before  = name_before in self._mf.event_objs and call_before_after
                 has_after   = name_after in self._mf.event_objs and call_before_after
                 fn_after    = getattr(self._mf.event, name_after) if has_after else None
@@ -115,7 +115,7 @@ class event(dict):
                         if has_before:
                             for fn_b in fn_before.fns:
                                 args, kwargs = fn_b(*args, **kwargs)
-                        res = fn(*miniflask_args,*args,**outer_locals,**kwargs)
+                        res = fn(*miniflask_args, *args, **outer_locals, **kwargs)
                         if has_after:
                             for fn_a in fn_after.fns:
                                 res, args, kwargs = fn_a(res, *args, **kwargs)
@@ -151,7 +151,7 @@ class event(dict):
                     fns, have_signature = zip(*[fn_wrap_scope(fn, state=module.state, event=module.event, module=module, skip_twice=True) for fn, module in zip(orig_fns,modules)])
                     def fn_wrap(*args, altfn=None, **kwargs):
                         results = []
-                        for i,fn in enumerate(fns):
+                        for i, fn in enumerate(fns):
                             results.append(fn(*args, **kwargs))
                         return results
                     return fn_wrap, fns, have_signature

--- a/src/miniflask/event.py
+++ b/src/miniflask/event.py
@@ -1,8 +1,4 @@
-from .exceptions import RegisterError
-import collections
 import inspect
-from functools import partial
-from colored import fg, attr
 
 class outervar():
     pass

--- a/src/miniflask/exceptions.py
+++ b/src/miniflask/exceptions.py
@@ -5,7 +5,7 @@ from colored import fg, attr
 def save_traceback():
     try:
         raise TracebackException("Could not register Variable.")
-    except TracebackException as e:
+    except TracebackException:
         full_tb = tb.extract_stack()
 
         # ignore this very function in the traceback

--- a/src/miniflask/exceptions.py
+++ b/src/miniflask/exceptions.py
@@ -1,5 +1,5 @@
 import traceback as tb
-from colored import fg, bg, attr
+from colored import fg, attr
 
 def save_traceback():
     try:

--- a/src/miniflask/exceptions.py
+++ b/src/miniflask/exceptions.py
@@ -16,7 +16,7 @@ class RegisterError(Exception):
 
     def __str__(self):
         base_exc = super().__str__()
-        return base_exc + ("\n\n"+fg('red')+"The variable definition occured in"+attr('reset')+":\n"""+format_traceback_list(self.traceback) if self.traceback is not None else "")
+        return base_exc + ("\n\n" + fg('red') + "The variable definition occured in" + attr('reset') + ":\n""" + format_traceback_list(self.traceback) if self.traceback is not None else "")
 
     def __init__(self, msg='', traceback=None, *args, **kwargs):
 
@@ -30,7 +30,7 @@ class StateKeyError(Exception):
 
     def __str__(self):
         base_exc = super().__str__()
-        return base_exc + ("\n\n"+fg('red')+"The Key Error occured in"+attr('reset')+":\n"""+format_traceback_list(self.traceback) if self.traceback is not None else "")
+        return base_exc + ("\n\n" + fg('red') + "The Key Error occured in" + attr('reset') + ":\n""" + format_traceback_list(self.traceback) if self.traceback is not None else "")
 
     def __init__(self, msg='', traceback=None, *args, **kwargs):
 
@@ -46,24 +46,24 @@ class TracebackException(Exception):
 
 def format_traceback_list(traceback_list, ignore_miniflask=True, exc=None):
     if ignore_miniflask:
-        traceback_list = [t for t in traceback_list if not t.filename.endswith("src/miniflask/event.py") and (not t.filename.endswith("src/miniflask/miniflask.py") or t.name in ["load","run"])]
+        traceback_list = [t for t in traceback_list if not t.filename.endswith("src/miniflask/event.py") and (not t.filename.endswith("src/miniflask/miniflask.py") or t.name in ["load", "run"])]
 
     # ignore "raise" lines
     if exc is not None and "raise" in traceback_list[-1].line:
         t = traceback_list[-1]
-        t.filename = fg('green')+t.filename+attr('reset')
-        t.lineno = fg('yellow')+str(t.lineno)+attr('reset')
-        t.name = fg('blue')+attr("bold")+t.name+attr('reset')
-        exception_type = fg('red')+attr('bold')+type(exc).__name__+attr('reset')
+        t.filename = fg('green') + t.filename + attr('reset')
+        t.lineno = fg('yellow') + str(t.lineno) + attr('reset')
+        t.name = fg('blue') + attr("bold") + t.name + attr('reset')
+        exception_type = fg('red') + attr('bold') + type(exc).__name__ + attr('reset')
         last_msg = "  File %s, line %s, in %s\n    %s: %s" % (t.filename, t.lineno, t.name, exception_type, str(exc))
         traceback_list = traceback_list[:-1]
     if exc is not None and not "raise" in traceback_list[-1].line:
-        exception_type = fg('red')+attr('bold')+type(exc).__name__+attr('reset')
+        exception_type = fg('red') + attr('bold') + type(exc).__name__ + attr('reset')
         last_msg = "    %s: %s" % (exception_type, str(exc))
     else:
         last_msg = ""
     for t in traceback_list:
-        t.filename = fg('green')+t.filename+attr('reset')
-        t.lineno = fg('yellow')+str(t.lineno)+attr('reset')
-        t.name = fg('blue')+attr("bold")+t.name+attr('reset')
-    return "".join(tb.format_list(traceback_list))+last_msg
+        t.filename = fg('green') + t.filename + attr('reset')
+        t.lineno = fg('yellow') + str(t.lineno) + attr('reset')
+        t.name = fg('blue') + attr("bold") + t.name + attr('reset')
+    return "".join(tb.format_list(traceback_list)) + last_msg

--- a/src/miniflask/exceptions.py
+++ b/src/miniflask/exceptions.py
@@ -1,6 +1,7 @@
 import traceback as tb
 from colored import fg, attr
 
+
 def save_traceback():
     try:
         raise TracebackException("Could not register Variable.")
@@ -9,6 +10,7 @@ def save_traceback():
 
         # ignore this very function in the traceback
         return full_tb[:-1]
+
 
 class RegisterError(Exception):
 
@@ -22,6 +24,7 @@ class RegisterError(Exception):
         self.traceback = traceback
 
         super().__init__(msg)
+
 
 class StateKeyError(Exception):
 
@@ -37,9 +40,9 @@ class StateKeyError(Exception):
         super().__init__(msg)
 
 
-
 class TracebackException(Exception):
     pass
+
 
 def format_traceback_list(traceback_list, ignore_miniflask=True, exc=None):
     if ignore_miniflask:

--- a/src/miniflask/exceptions.py
+++ b/src/miniflask/exceptions.py
@@ -57,7 +57,7 @@ def format_traceback_list(traceback_list, ignore_miniflask=True, exc=None):
         exception_type = fg('red') + attr('bold') + type(exc).__name__ + attr('reset')
         last_msg = "  File %s, line %s, in %s\n    %s: %s" % (t.filename, t.lineno, t.name, exception_type, str(exc))
         traceback_list = traceback_list[:-1]
-    if exc is not None and not "raise" in traceback_list[-1].line:
+    if exc is not None and "raise" not in traceback_list[-1].line:
         exception_type = fg('red') + attr('bold') + type(exc).__name__ + attr('reset')
         last_msg = "    %s: %s" % (exception_type, str(exc))
     else:

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -22,8 +22,8 @@ import re
 from enum import Enum, EnumMeta
 
 
-def print_info(*args,color=fg('green'),msg="INFO"):
-    print(color+attr('bold')+msg+attr('reset')+color+": "+attr('reset'),*args,attr('reset'))
+def print_info(*args, color=fg('green'), msg="INFO"):
+    print(color + attr('bold') + msg + attr('reset') + color + ": " + attr('reset'), *args, attr('reset'))
 
 
 def get_default_args(func):
@@ -46,19 +46,19 @@ class miniflask():
             return
 
         # module dir to be read from
-        if isinstance(module_dirs,list):
-            self.module_dirs = {path.basename(m):m for m in module_dirs}
-        elif isinstance(module_dirs,str):
-            self.module_dirs = {path.basename(module_dirs):module_dirs}
-        elif isinstance(module_dirs,dict):
+        if isinstance(module_dirs, list):
+            self.module_dirs = {path.basename(m): m for m in module_dirs}
+        elif isinstance(module_dirs, str):
+            self.module_dirs = {path.basename(module_dirs): module_dirs}
+        elif isinstance(module_dirs, dict):
             self.module_dirs = module_dirs
         else:
             raise ValueError("Only dict or list allowed for `module_dirs'. Found type '%s'." % type(module_dirs))
         for dir in self.module_dirs.values():
-            sys.path.insert(0,dir+path.sep+path.pardir)
+            sys.path.insert(0, dir + path.sep + path.pardir)
 
         # arguments from cli-stdin
-        self.settings_parser = ArgumentParser(usage=sys.argv[0]+" modulelist [optional arguments]")
+        self.settings_parser = ArgumentParser(usage=sys.argv[0] + " modulelist [optional arguments]")
         self._settings_parse_later = {}
         self._settings_parse_later_overwrites_list = []
         self._settings_parse_later_overwrites = {}
@@ -76,7 +76,7 @@ class miniflask():
         self.state_default = {}
         self.modules_loaded = {}
         self.modules_avail = getModulesAvail(self.module_dirs)
-        self.miniflask_objs = {} # local modified versions of miniflask
+        self.miniflask_objs = {}  # local modified versions of miniflask
         registerPredefined(self.modules_avail)
         self._varid_list = []
         self._recently_loaded = []
@@ -88,13 +88,13 @@ class miniflask():
     # ------- #
     # helpers #
     # ------- #
-    def print_heading(self,*args,color=fg('green'),margin=8):
-        line = "—"*self._consolecolumns
+    def print_heading(self, *args, color=fg('green'), margin=8):
+        line = "—" * self._consolecolumns
         if len(args) > 0:
             s = " ".join(args)
-            line = line[:margin] + " " + s + " " + line[margin+len(s)+2:]
+            line = line[:margin] + " " + s + " " + line[margin + len(s) + 2:]
         print()
-        print(fg('blue')+attr('bold')+line+attr('reset'))
+        print(fg('blue') + attr('bold') + line + attr('reset'))
 
     def print_recently_loaded(self, prepend="", loading_text=highlight_loading):
         for i, mod in enumerate(self._recently_loaded):
@@ -102,20 +102,20 @@ class miniflask():
             is_last = i == len(self._recently_loaded) - 1
             has_children = len(mod.miniflask_obj._recently_loaded) > 0
             if is_last:
-                tree_symb         = "    " #"└── "
+                tree_symb         = "    "  # "└── "
                 tree_symb_current = "╰── "
             elif has_children:
                 tree_symb         = "│   "
                 tree_symb_current = "│   "
             else:
-                tree_symb         = "│   " #"├── "
+                tree_symb         = "│   "  # "├── "
                 tree_symb_current = "├── "
             if prepend == "":
                 print(loading_text(module_id))
             else:
-                print(prepend+tree_symb_current+loading_text(module_id))
+                print(prepend + tree_symb_current + loading_text(module_id))
             if len(mod.miniflask_obj._recently_loaded) > 0:
-                mod.miniflask_obj.print_recently_loaded(prepend+tree_symb, loading_text)
+                mod.miniflask_obj.print_recently_loaded(prepend + tree_symb, loading_text)
 
     # ==================== #
     # module introspection #
@@ -128,7 +128,7 @@ class miniflask():
 
         # load module
         mod = import_module(self.modules_avail[module]["importpath"])
-        if not hasattr(mod,"register"):
+        if not hasattr(mod, "register"):
             return []
 
         mod.register(dummy)
@@ -138,7 +138,7 @@ class miniflask():
     def showModules(self, dir=None, prepend="", id_pre=None, with_event=True):
         if not dir:
             for basename, dir in self.module_dirs.items():
-                self.showModules(dir, prepend=prepend, id_pre=basename if id_pre is None else id_pre+"."+basename, with_event=with_event)
+                self.showModules(dir, prepend=prepend, id_pre=basename if id_pre is None else id_pre + "." + basename, with_event=with_event)
             return
 
         if id_pre is None:
@@ -146,29 +146,29 @@ class miniflask():
         if len(prepend) == 0:
             print()
             print(highlight_name(path.basename(id_pre)))
-        dirs = [d for d in listdir(dir) if path.isdir(path.join(dir,d)) and not d.startswith("_")]
+        dirs = [d for d in listdir(dir) if path.isdir(path.join(dir, d)) and not d.startswith("_")]
         for i, d in enumerate(dirs):
             if d.startswith("."):
                 continue
-            if path.exists(path.join(dir,d,".ignoredir")):
+            if path.exists(path.join(dir, d, ".ignoredir")):
                 continue
             module_id = id_pre + "." + d if id_pre != "" else d
 
-            is_module = path.exists(path.join(dir,d,".module"))
-            is_lowpriority_module = path.exists(path.join(dir,d,".lowpriority"))
+            is_module = path.exists(path.join(dir, d, ".module"))
+            is_lowpriority_module = path.exists(path.join(dir, d, ".lowpriority"))
             if is_module:
                 shortestid = self.getModuleShortId(module_id)
             has_shortid = is_module and shortestid == d
 
-            if i == len(dirs)-1:
+            if i == len(dirs) - 1:
                 tree_symb = "└── "
                 is_last = True
             else:
                 tree_symb = "├── "
                 is_last = False
-            append = " "+fg('blue')+"("+shortestid+")"+attr('reset') if is_module and not has_shortid else ""
-            append += attr('dim')+" (low-priority module)"+attr('reset') if is_lowpriority_module else ""
-            print(prepend+tree_symb+(highlight_name(d) if is_module else d)+append)
+            append = " " + fg('blue') + "(" + shortestid + ")" + attr('reset') if is_module and not has_shortid else ""
+            append += attr('dim') + " (low-priority module)" + attr('reset') if is_lowpriority_module else ""
+            print(prepend + tree_symb + (highlight_name(d) if is_module else d) + append)
 
             tree_symb_next = "     " if is_last else "│    "
             if is_module:
@@ -177,9 +177,9 @@ class miniflask():
                     if len(events) > 0:
                         for e in events:
                             unique_flag = "!" if e[1] else ">"
-                            print(prepend+tree_symb_next+unique_flag+" "+highlight_event(e[0]))
+                            print(prepend + tree_symb_next + unique_flag + " " + highlight_event(e[0]))
                 continue
-            self.showModules(path.join(dir,d),prepend=prepend+tree_symb_next, id_pre=module_id, with_event=with_event)
+            self.showModules(path.join(dir, d), prepend=prepend + tree_symb_next, id_pre=module_id, with_event=with_event)
 
     # pretty print loaded modules
     def __str__(self):
@@ -194,7 +194,7 @@ class miniflask():
     # get unique id of a moodule
     def getModuleId(self, module_id):
         module_ids = self.modules_avail.keys()
-        module = module_id.replace(".","\.(.*\.)*")
+        module = module_id.replace(".", "\.(.*\.)*")
 
         # first search for a default module
         r = re.compile("^(.*\.)?%s(\..*)?\.(default|%s)$" % (module, module_id.split(".")[-1]))
@@ -216,11 +216,11 @@ class miniflask():
 
         # if more than one module found let the user know
         if len(found_modules) > 1:
-            raise ValueError(highlight_error()+"Module-Identifier '%s' is not unique. Found %i modules:\n\t%s" % (highlight_module(module_id), len(found_modules), "\n\t".join(found_modules)))
+            raise ValueError(highlight_error() + "Module-Identifier '%s' is not unique. Found %i modules:\n\t%s" % (highlight_module(module_id), len(found_modules), "\n\t".join(found_modules)))
 
         # no module found with both variants
         elif len(found_modules) == 0:
-            raise ValueError(highlight_error()+"Module '%s' not known." % highlight_module(module_id))
+            raise ValueError(highlight_error() + "Module '%s' not known." % highlight_module(module_id))
 
         # module_id is a unique identifier
         module = found_modules[0]
@@ -229,7 +229,7 @@ class miniflask():
     # get short id of a moodule
     def getModuleShortId(self, module):
         if not module in self.modules_avail:
-            raise ValueError(highlight_error()+"Module '%s' not known." % highlight_module(module))
+            raise ValueError(highlight_error() + "Module '%s' not known." % highlight_module(module))
         uniqueId = self.modules_avail[module]["id"].split(".")
 
         # modA.default -> modA
@@ -237,7 +237,7 @@ class miniflask():
             uniqueId = uniqueId[:-1]
 
         # find the shortest substring to match a module uniquely
-        for i in range(len(uniqueId)-1,0,-1):
+        for i in range(len(uniqueId) - 1, 0, -1):
             shortid = ".".join(uniqueId[i:])
             try:
                 if module == self.getModuleId(shortid):
@@ -254,9 +254,9 @@ class miniflask():
         # try to use scope.default as module id
         if scope is not None:
             try:
-                module_id = self.getModuleId(scope+".default")
+                module_id = self.getModuleId(scope + ".default")
                 if varid.startswith(scope):
-                    varid = varid[len(scope)+1:]
+                    varid = varid[len(scope) + 1:]
                 return module_id, varid
             except ValueError as e:
                 pass
@@ -265,7 +265,7 @@ class miniflask():
             try:
                 module_id = self.getModuleId(scope)
                 if varid.startswith(scope):
-                    varid = varid[len(scope)+1:]
+                    varid = varid[len(scope) + 1:]
                 return module_id, varid
             except ValueError as e:
                 pass
@@ -273,7 +273,7 @@ class miniflask():
         # no we have to work out which module may be meant
         if varid_list is None:
             varid_list = varid.split(".")
-        for i in range(len(varid_list)-1,0,-1):
+        for i in range(len(varid_list) - 1, 0, -1):
             test_id = ".".join(varid_list[:i])
             try:
                 return self.getModuleId(test_id), ".".join(varid_list[i:])
@@ -289,7 +289,7 @@ class miniflask():
         # load list of modules
         if isinstance(module_name, str) and "," in module_name:
             module_name = module_name.split(",")
-        if isinstance(module_name,list):
+        if isinstance(module_name, list):
             for m in module_name:
                 self.load(m, verbose=verbose, auto_query=auto_query, loading_text=loading_text, as_id=as_id, bind_events=bind_events)
             return
@@ -298,16 +298,16 @@ class miniflask():
         if auto_query:
             module_name = self.getModuleId(module_name)
         elif not module_name in self.modules_avail:
-            raise ValueError(highlight_error()+"Module '%s' not known." % highlight_module(module_name))
+            raise ValueError(highlight_error() + "Module '%s' not known." % highlight_module(module_name))
 
         # check if already loaded
-        if module_name+".default" in self.modules_loaded or module_name in self.modules_loaded and as_id is None:
+        if module_name + ".default" in self.modules_loaded or module_name in self.modules_loaded and as_id is None:
             return
 
         # load module
         mod = import_module(self.modules_avail[module_name]["importpath"])
-        if not hasattr(mod,"register"):
-            raise ValueError(highlight_error()+"Module '%s' does not register itself." % module_name)
+        if not hasattr(mod, "register"):
+            raise ValueError(highlight_error() + "Module '%s' does not register itself." % module_name)
         module_name = module_name if as_id is None else as_id
         mod.miniflask_obj = miniflask_wrapper(module_name, self)
         mod.miniflask_obj.bind_events = bind_events
@@ -345,11 +345,11 @@ class miniflask():
 
             # catch some user errors
             if not unique and self.event_objs[name].unique:
-                raise RegisterError(highlight_error()+"Event '%s' has been registered as `unique` before, but as `non-unique` now. Please check the registrations.\n\t(Imported by %s)" % (highlight_event(name),", ".join(["'"+highlight_module(e.module_name)+"'" for e in eobj])))
+                raise RegisterError(highlight_error() + "Event '%s' has been registered as `unique` before, but as `non-unique` now. Please check the registrations.\n\t(Imported by %s)" % (highlight_event(name), ", ".join(["'" + highlight_module(e.module_name) + "'" for e in eobj])))
             if unique and not self.event_objs[name].unique:
-                raise RegisterError(highlight_error()+"Event '%s' has been registered as `non-unique` before, but as `unique` now. Please check the registrations.\n\t(Imported by %s)" % (highlight_event(name),", ".join(["'"+highlight_module(e.module_name)+"'" for e in eobj])))
+                raise RegisterError(highlight_error() + "Event '%s' has been registered as `non-unique` before, but as `unique` now. Please check the registrations.\n\t(Imported by %s)" % (highlight_event(name), ", ".join(["'" + highlight_module(e.module_name) + "'" for e in eobj])))
 
-            raise RegisterError(highlight_error()+"Event '%s' is unique, and thus, cannot be imported twice.\n\t(Imported by %s)" % (highlight_event(name),", ".join(["'"+highlight_module(e.module_name)+"'" for e in eobj])))
+            raise RegisterError(highlight_error() + "Event '%s' is unique, and thus, cannot be imported twice.\n\t(Imported by %s)" % (highlight_event(name), ", ".join(["'" + highlight_module(e.module_name) + "'" for e in eobj])))
 
         # register event
         if name in self.event_objs:
@@ -374,11 +374,11 @@ class miniflask():
         for key, val in defaults.items():
 
             # unique & full varname is fully defined using scope
-            varname = scope+"."+key if len(scope) > 0 else key
+            varname = scope + "." + key if len(scope) > 0 else key
             key_split = varname.split(".")
 
             # get module id from global varname identifier
-            module_id, key = self._getModuleIdFromVarId(varname,key_split,scope=scope)
+            module_id, key = self._getModuleIdFromVarId(varname, key_split, scope=scope)
             if module_id is not None:
 
                 # recreate actual key
@@ -387,12 +387,12 @@ class miniflask():
 
             # actual initialization is done when all modules has been parsed
             if overwrite:
-                self._settings_parse_later_overwrites_list.append((varname, val, cliargs, parsefn, caller_traceback, self) )
+                self._settings_parse_later_overwrites_list.append((varname, val, cliargs, parsefn, caller_traceback, self))
             else:
 
                 # pre-initialize variable for possible lambda expressions in second pass
                 # (we can only be sure, that the varname is the unique varid if we are not overwriting)
-                if hasattr(self.state,"all"):
+                if hasattr(self.state, "all"):
                     self.state.all[varname] = val
                 else:
                     self.state[varname] = val
@@ -402,9 +402,9 @@ class miniflask():
     def _settings_parser_add(self, varname, val, caller_traceback, nargs=None, default=None):
 
         # lists are just multiple arguments
-        if isinstance(val,list) or isinstance(val,tuple):
+        if isinstance(val, list) or isinstance(val, tuple):
             if len(val) == 0:
-                raise RegisterError("Variable '%s' is registered as list (see exception below), however it is required to define the type of the list arguments for it to become accessible from cli.\n\nYour options are:\n\t- define a default list, e.g. [\"a\", \"b\", \"c\"]\n\t- define the list type, e.g. [str]\n\t- define the variable as a helper using register_helpers(...)" % (fg('red')+varname+attr('reset')), traceback=caller_traceback)
+                raise RegisterError("Variable '%s' is registered as list (see exception below), however it is required to define the type of the list arguments for it to become accessible from cli.\n\nYour options are:\n\t- define a default list, e.g. [\"a\", \"b\", \"c\"]\n\t- define the list type, e.g. [str]\n\t- define the variable as a helper using register_helpers(...)" % (fg('red') + varname + attr('reset')), traceback=caller_traceback)
             self._settings_parser_add(varname, val[0], caller_traceback, nargs="+", default=val)
             return
 
@@ -435,15 +435,15 @@ class miniflask():
             kwarg["const"] = True
 
         # define the actual arguments
-        if argtype in [int,str,float,str2bool,Enum]:
-            self.settings_parser.add_argument( "--"+varname, **kwarg)
+        if argtype in [int, str, float, str2bool, Enum]:
+            self.settings_parser.add_argument("--" + varname, **kwarg)
         else:
             raise ValueError("Type '%s' not supported. (Used for setting '%s')" % (type(val), varname))
 
         # for bool: enable --no-varname as alternative for --varname false
         # Note: this has to be defined AFTER --varname
         if argtype == str2bool and nargs != '+':
-            self.settings_parser.add_argument('--no-'+varname, dest=varname, action='store_false')
+            self.settings_parser.add_argument('--no-' + varname, dest=varname, action='store_false')
 
         # remember the varname also for fuzzy searching
         self._varid_list.append(varname)
@@ -459,9 +459,9 @@ class miniflask():
             raise SystemError("The function `parse_args` has been called already. Did you maybe called `mf.parse_args()` and `mf.run()` in the same script? Solutions are:\n\t- Please use only one of those functions.\n\t- If you actually need both functions, please do not hesitate to write an issue on\n\t\thttps://github/da-h/miniflask/issues\n\t  to explain you used case.\n\t  (It's not hard to implement, but I need to know, if and when this functionality is needed. ;) )")
 
         if not argv:
-            argv = sys.argv#[1:]
+            argv = sys.argv  # [1:]
         else:
-            argv = [None]+argv
+            argv = [None] + argv
 
         # actually parse the input
         parser = ArgumentParser()
@@ -489,18 +489,18 @@ class miniflask():
             self.print_heading("Loading Automatically Requested Default Modules")
         for module, event, glob, overwrite_globals, caller_traceback in self.default_modules:
             if event:
-                if not isinstance(module,list):
+                if not isinstance(module, list):
                     module = [module]
                 modules_already_loaded = all(self.getModuleId(m) in self.modules_loaded for m in module)
                 if not modules_already_loaded and not event in self.event_objs:
-                    self.load(module, loading_text=lambda x: highlight_loading_default(event,x))
+                    self.load(module, loading_text=lambda x: highlight_loading_default(event, x))
                     self.register_defaults(overwrite_globals, scope="", overwrite=True, caller_traceback=caller_traceback)
                 else:
                     found = self.event_objs[event].modules
-                    if not isinstance(found,list):
+                    if not isinstance(found, list):
                         found = [found]
                     found = [f.module_id for f in found]
-                    print(highlight_loaded_default(found,event))
+                    print(highlight_loaded_default(found, event))
 
                 # overwrite defaults if loaded default module itself or did not load module yet
                 if modules_already_loaded:
@@ -509,19 +509,19 @@ class miniflask():
             elif glob:
                 found = [highlight_loading_module(x) for x in keys if re.search(glob, x)]
                 if len(found) == 0:
-                    self.load(module, loading_text=lambda x: highlight_loading_default(glob,x))
+                    self.load(module, loading_text=lambda x: highlight_loading_default(glob, x))
                     self.register_defaults(overwrite_globals, scope="", overwrite=True, caller_traceback=caller_traceback)
                 elif len(found) > 1:
-                    print(highlight_loaded_default(found,glob))
+                    print(highlight_loaded_default(found, glob))
                 else:
-                    print(highlight_loaded_default(found,glob))
+                    print(highlight_loaded_default(found, glob))
 
         # check fuzzy matching of overwrites
         for varname, val, cliargs, parsefn, caller_traceback, _mf in self._settings_parse_later_overwrites_list:
             if varname not in self._settings_parse_later:
-                found_varids = get_varid_from_fuzzy(varname,self._settings_parse_later.keys()) 
+                found_varids = get_varid_from_fuzzy(varname, self._settings_parse_later.keys())
                 if len(found_varids) == 0:
-                    raise RegisterError("Variable '%s' is not registered yet, however it seems like you wold like to overwrite it (see exception below)." % (fg('red')+varname+attr('reset')), traceback=caller_traceback)
+                    raise RegisterError("Variable '%s' is not registered yet, however it seems like you wold like to overwrite it (see exception below)." % (fg('red') + varname + attr('reset')), traceback=caller_traceback)
                 elif len(found_varids) > 1:
                     raise RegisterError("Variable-Identifier '%s' is not unique. Found %i variables:\n\t%s\n\n    Call:\n        %s" % (highlight_module(found_varids), len(found_varids), "\n\t".join(found_varids), " ".join(found_varids)), traceback=caller_traceback)
                 else:
@@ -531,8 +531,8 @@ class miniflask():
 
         # add variables to argparse and remember defaults
         settings_recheck = {}
-        for settings in [self._settings_parse_later,self._settings_parse_later_overwrites, settings_recheck]:
-            overwrite = settings == self._settings_parse_later_overwrites 
+        for settings in [self._settings_parse_later, self._settings_parse_later_overwrites, settings_recheck]:
+            overwrite = settings == self._settings_parse_later_overwrites
             recheck = settings == settings_recheck
             for varname, (val, cliargs, parsefn, caller_traceback, _mf) in settings.items():
                 is_fn = callable(val) and type(val) != type and type(val) != EnumMeta and parsefn
@@ -542,7 +542,7 @@ class miniflask():
                     try:
                         the_val = val
                         while callable(the_val) and type(the_val) != type:
-                            the_val = the_val(_mf.state,self.event)
+                            the_val = the_val(_mf.state, self.event)
                     except RecursionError as e:
                         raise RecursionError("In parsing of value '%s'." % varname)
                 else:
@@ -581,15 +581,15 @@ class miniflask():
             print_help = True
 
         # split --varname=value expressions
-        argv = [v  for val in argv for v in (val.split("=",1) if val.startswith("--") or val.startswith("-") and not val[1:].isnumeric() else [val])]
+        argv = [v for val in argv for v in (val.split("=", 1) if val.startswith("--") or val.startswith("-") and not val[1:].isnumeric() else [val])]
 
         # remember varids from user-args & fuzzy matching the settings
         user_varids = {}
         for i in range(len(argv)):
             varid = argv[i]
             if not varid.startswith("--"):
-                if varid.startswith("-") and not varid[1:].replace('.','',1).isdigit():
-                    varid = argv[i] = "-"+argv[i]
+                if varid.startswith("-") and not varid[1:].replace('.', '', 1).isdigit():
+                    varid = argv[i] = "-" + argv[i]
                 else:
                     continue
 
@@ -614,17 +614,17 @@ class miniflask():
                 # if no matching varid found, check for fuzzy identifier
                 if len(found_varids) > 1:
                     argv[i] = highlight_module(argv[i])
-                    raise ValueError(highlight_error()+"Variable-Identifier '--%s' is not unique. Found %i variables:\n\t%s\n\n    Call:\n        %s" % (highlight_module(varid), len(found_varids), "\n\t".join(found_varids), " ".join(argv)))
+                    raise ValueError(highlight_error() + "Variable-Identifier '--%s' is not unique. Found %i variables:\n\t%s\n\n    Call:\n        %s" % (highlight_module(varid), len(found_varids), "\n\t".join(found_varids), " ".join(argv)))
 
                 # no module found with both variants
                 elif len(found_varids) == 0:
                     argv[i] = highlight_module(argv[i])
-                    raise ValueError(highlight_error()+"Variable '--%s' not known.\n\n    Call:\n       %s" % (highlight_module(varid)," ".join(argv)))
+                    raise ValueError(highlight_error() + "Variable '--%s' not known.\n\n    Call:\n       %s" % (highlight_module(varid), " ".join(argv)))
 
                 varid = found_varids[0]
 
                 # replace with fuzzy-found varid
-                argv[i] = ("--no-" if was_false_bool else "--")+found_varids[0]
+                argv[i] = ("--no-" if was_false_bool else "--") + found_varids[0]
 
             # remember this varid has been overwritten by the user
             user_varids[varid] = True
@@ -640,7 +640,7 @@ class miniflask():
             if self.state[variables[0]] is None:
                 missing_arguments.append(variables)
         if len(missing_arguments) > 0:
-            self.settings_parser.error(linesep+linesep.join(["The following argument is required: "+" or ".join(["--"+arg for arg in reversed(args)]) for args in missing_arguments]))
+            self.settings_parser.error(linesep + linesep.join(["The following argument is required: " + " or ".join(["--" + arg for arg in reversed(args)]) for args in missing_arguments]))
 
         # finally parse lambda-dependencies
         for varname, (val, cliargs, parsefn, caller_traceback, _mf) in self._settings_parse_later.items():
@@ -650,11 +650,11 @@ class miniflask():
             # 1. was helper variable, thus no cli-argument can overwrite it anyway
             # 2. the value has not been overwritten by user
             while callable(val) and type(val) != type and type(val) != EnumMeta and parsefn and (not cliargs or varname not in user_varids):
-                val = val(_mf.state,_mf.event)
+                val = val(_mf.state, _mf.event)
                 self.state[varname] = val
 
         # print help message when everything is parsed
-        self.settings_parser.print_help = lambda: (print("usage: modulelist [optional arguments]"),print(),print("optional arguments (and their defaults):"),print(listsettings(state("",self.state,self.state_default),self.event)))
+        self.settings_parser.print_help = lambda: (print("usage: modulelist [optional arguments]"), print(), print("optional arguments (and their defaults):"), print(listsettings(state("", self.state, self.state_default), self.event)))
         if print_help:
             self.settings_parser.parse_args(['--help'])
 
@@ -676,7 +676,7 @@ class miniflask():
             if not self.halt_parse:
 
                 # optional init event
-                if hasattr(self.event,'init'):
+                if hasattr(self.event, 'init'):
                     self.print_heading("init Event")
                     self.event.optional.init()
 
@@ -694,14 +694,14 @@ class miniflask():
                     print("No event '{0}' registered. "
                           "Please make sure to register the event '{0}', "
                           "or provide a suitable event to call with mf.run(call=\"myevent\").".format(call))
-        except (RegisterError,StateKeyError) as e:
+        except (RegisterError, StateKeyError) as e:
             gettrace = getattr(sys, 'gettrace', None)
 
             # check if debugger will catch this
             if not gettrace or not gettrace():
                 tb = traceback.extract_tb(e.__traceback__)
                 print()
-                print(fg("red")+"Uncatched Exception occured. Traceback:"+attr("reset"))
+                print(fg("red") + "Uncatched Exception occured. Traceback:" + attr("reset"))
                 print(format_traceback_list(tb, exc=e, ignore_miniflask=False))
                 sys.exit(1)
             else:
@@ -713,7 +713,7 @@ class miniflask():
             if not gettrace or not gettrace():
                 tb = traceback.extract_tb(e.__traceback__)
                 print()
-                print(fg("red")+"Uncatched Exception occured. Traceback:"+attr("reset"))
+                print(fg("red") + "Uncatched Exception occured. Traceback:" + attr("reset"))
                 print(format_traceback_list(tb, exc=e, ignore_miniflask=not self.debug))
                 sys.exit(1)
             else:
@@ -743,11 +743,11 @@ class miniflask_wrapper(miniflask):
             if upmodule == offset:
                 module_name = self.module_id + ("." + relative_module if relative_module else "")
             else:
-                module_name = ".".join(self.module_id.split(".")[:-upmodule+offset]) + ("." + relative_module if relative_module else "")
+                module_name = ".".join(self.module_id.split(".")[:-upmodule + offset]) + ("." + relative_module if relative_module else "")
             was_relative = True
         return module_name, was_relative
 
-    def __getattr__(self,attr):
+    def __getattr__(self, attr):
         orig_attr = super().__getattribute__('wrapped_class').__getattribute__(attr)
         if callable(orig_attr):
             def hooked(*args, **kwargs):
@@ -760,7 +760,7 @@ class miniflask_wrapper(miniflask):
         else:
             return orig_attr
 
-    def redefine_scope(self,new_module_name):
+    def redefine_scope(self, new_module_name):
         old_module_name = self.module_id
         new_module_name = self.set_scope(new_module_name)
         if new_module_name in self.modules_avail:
@@ -770,7 +770,7 @@ class miniflask_wrapper(miniflask):
         m["id"] = new_module_name
         self.modules_avail[new_module_name] = m
 
-    def set_scope(self,new_module_name):
+    def set_scope(self, new_module_name):
         new_module_name, was_relative = self._get_relative_module_id(new_module_name)
         if not was_relative:
             new_module_name = self.module_base + "." + new_module_name

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -228,7 +228,7 @@ class miniflask():
 
     # get short id of a moodule
     def getModuleShortId(self, module):
-        if not module in self.modules_avail:
+        if module not in self.modules_avail:
             raise ValueError(highlight_error() + "Module '%s' not known." % highlight_module(module))
         uniqueId = self.modules_avail[module]["id"].split(".")
 
@@ -297,7 +297,7 @@ class miniflask():
         # get id
         if auto_query:
             module_name = self.getModuleId(module_name)
-        elif not module_name in self.modules_avail:
+        elif module_name not in self.modules_avail:
             raise ValueError(highlight_error() + "Module '%s' not known." % highlight_module(module_name))
 
         # check if already loaded
@@ -492,7 +492,7 @@ class miniflask():
                 if not isinstance(module, list):
                     module = [module]
                 modules_already_loaded = all(self.getModuleId(m) in self.modules_loaded for m in module)
-                if not modules_already_loaded and not event in self.event_objs:
+                if not modules_already_loaded and event not in self.event_objs:
                     self.load(module, loading_text=lambda x: highlight_loading_default(event, x))
                     self.register_defaults(overwrite_globals, scope="", overwrite=True, caller_traceback=caller_traceback)
                 else:

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -4,7 +4,7 @@ from .event import event, event_obj
 from .state import state, like
 from .dummy import miniflask_dummy
 from .util import getModulesAvail, EnumAction
-from .util import highlight_error, highlight_name, highlight_module, highlight_loading, highlight_loading_default, highlight_loaded_default, highlight_loading_module, highlight_loaded_none, highlight_loaded, highlight_event, highlight_type, highlight_val, highlight_val_overwrite, str2bool, get_varid_from_fuzzy
+from .util import highlight_error, highlight_name, highlight_module, highlight_loading, highlight_loading_default, highlight_loaded_default, highlight_loading_module, highlight_loaded_none, highlight_loaded, highlight_event, str2bool, get_varid_from_fuzzy
 
 
 from .modules import registerPredefined
@@ -15,11 +15,9 @@ import inspect
 import traceback
 import sys
 from os import path, listdir, linesep, get_terminal_size
-from colored import fg, bg, attr
+from colored import fg, attr
 from importlib import import_module
-from copy import copy
-from argparse import ArgumentParser, SUPPRESS as argparse_SUPPRESS
-from queue import Queue
+from argparse import ArgumentParser
 import re
 from enum import Enum, EnumMeta
 

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -244,7 +244,7 @@ class miniflask():
                     return shortid
                 else:
                     pass
-            except ValueError as e:
+            except ValueError:
                 pass
         return module
 
@@ -258,7 +258,7 @@ class miniflask():
                 if varid.startswith(scope):
                     varid = varid[len(scope) + 1:]
                 return module_id, varid
-            except ValueError as e:
+            except ValueError:
                 pass
 
             # try to use scope as module id
@@ -267,7 +267,7 @@ class miniflask():
                 if varid.startswith(scope):
                     varid = varid[len(scope) + 1:]
                 return module_id, varid
-            except ValueError as e:
+            except ValueError:
                 pass
 
         # no we have to work out which module may be meant
@@ -277,7 +277,7 @@ class miniflask():
             test_id = ".".join(varid_list[:i])
             try:
                 return self.getModuleId(test_id), ".".join(varid_list[i:])
-            except ValueError as e:
+            except ValueError:
                 pass
 
         # no id could be derived
@@ -543,7 +543,7 @@ class miniflask():
                         the_val = val
                         while callable(the_val) and type(the_val) != type:
                             the_val = the_val(_mf.state, self.event)
-                    except RecursionError as e:
+                    except RecursionError:
                         raise RecursionError("In parsing of value '%s'." % varname)
                 else:
                     the_val = val

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -21,8 +21,10 @@ from argparse import ArgumentParser
 import re
 from enum import Enum, EnumMeta
 
+
 def print_info(*args,color=fg('green'),msg="INFO"):
     print(color+attr('bold')+msg+attr('reset')+color+": "+attr('reset'),*args,attr('reset'))
+
 
 def get_default_args(func):
     signature = inspect.signature(func)
@@ -83,8 +85,6 @@ class miniflask():
         except:
             self._consolecolumns, self._consolerows = 80, 40
 
-
-
     # ------- #
     # helpers #
     # ------- #
@@ -116,7 +116,6 @@ class miniflask():
                 print(prepend+tree_symb_current+loading_text(module_id))
             if len(mod.miniflask_obj._recently_loaded) > 0:
                 mod.miniflask_obj.print_recently_loaded(prepend+tree_symb, loading_text)
-
 
     # ==================== #
     # module introspection #
@@ -187,7 +186,6 @@ class miniflask():
         if len(self.modules_loaded) == 0:
             return highlight_loaded_none("No Loaded Modules")
         return highlight_loaded("Loaded Modules:", self.modules_loaded.keys())
-
 
     # =================== #
     # module registration #
@@ -327,7 +325,6 @@ class miniflask():
         if verbose:
             self.print_recently_loaded(prepend="", loading_text=loading_text)
             self._recently_loaded = []
-
 
     # register default module that is loaded if none of glob is matched
     def register_default_module(self, module, required_event=None, required_id=None, overwrite_globals={}):
@@ -519,7 +516,6 @@ class miniflask():
                 else:
                     print(highlight_loaded_default(found,glob))
 
-
         # check fuzzy matching of overwrites
         for varname, val, cliargs, parsefn, caller_traceback, _mf in self._settings_parse_later_overwrites_list:
             if varname not in self._settings_parse_later:
@@ -574,7 +570,6 @@ class miniflask():
                     # Note: the condition ensures that the last value (an overwrite-variable) should be the one that generates the argparser)
                     if recheck or overwrite and varname not in settings_recheck or varname not in self._settings_parse_later_overwrites and varname not in settings_recheck:
                         self._settings_parser_add(varname, the_val, caller_traceback)
-
 
         # add help message
         print_help = False
@@ -724,7 +719,10 @@ class miniflask():
             else:
                 raise
 
+
 relative_import_re = re.compile("(\.+)(.*)")
+
+
 class miniflask_wrapper(miniflask):
     def __init__(self, module_name, mf):
         self.module_id = module_name
@@ -847,4 +845,3 @@ class miniflask_wrapper(miniflask):
     # overwrites previously registered variables
     def overwrite_defaults(self, defaults, scope=None, **kwargs):
         self.register_defaults(defaults, scope=scope, overwrite=True, **kwargs)
-

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -82,7 +82,7 @@ class miniflask():
         self._recently_loaded = []
         try:
             self._consolecolumns, self._consolerows = get_terminal_size(0)
-        except:
+        except:  # noqa: E722
             self._consolecolumns, self._consolerows = 80, 40
 
     # ------- #
@@ -102,14 +102,14 @@ class miniflask():
             is_last = i == len(self._recently_loaded) - 1
             has_children = len(mod.miniflask_obj._recently_loaded) > 0
             if is_last:
-                tree_symb         = "    "  # "└── "
-                tree_symb_current = "╰── "
+                tree_symb         = "    "  # noqa: E221
+                tree_symb_current = "╰── "  # "└── "
             elif has_children:
-                tree_symb         = "│   "
+                tree_symb         = "│   "  # noqa: E221
                 tree_symb_current = "│   "
             else:
-                tree_symb         = "│   "  # "├── "
-                tree_symb_current = "├── "
+                tree_symb         = "│   "  # noqa: E221
+                tree_symb_current = "├── "  # "├── "
             if prepend == "":
                 print(loading_text(module_id))
             else:
@@ -135,7 +135,7 @@ class miniflask():
         return dummy.getEvents()
 
     # pretty print of all available modules
-    def showModules(self, dir=None, prepend="", id_pre=None, with_event=True):
+    def showModules(self, dir=None, prepend="", id_pre=None, with_event=True):  # noqa: C901 too-complex
         if not dir:
             for basename, dir in self.module_dirs.items():
                 self.showModules(dir, prepend=prepend, id_pre=basename if id_pre is None else id_pre + "." + basename, with_event=with_event)
@@ -249,7 +249,7 @@ class miniflask():
         return module
 
     # maps 'folder.subfolder.module.list.of.vars' to 'folder.subfoldder.module'
-    def _getModuleIdFromVarId(self, varid, varid_list=None, scope=None):
+    def _getModuleIdFromVarId(self, varid, varid_list=None, scope=None):  # noqa: C901 too-complex
 
         # try to use scope.default as module id
         if scope is not None:
@@ -399,7 +399,7 @@ class miniflask():
 
                 self._settings_parse_later[varname] = (val, cliargs, parsefn, caller_traceback, self)
 
-    def _settings_parser_add(self, varname, val, caller_traceback, nargs=None, default=None):
+    def _settings_parser_add(self, varname, val, caller_traceback, nargs=None, default=None):  # noqa: C901 too-complex
 
         # lists are just multiple arguments
         if isinstance(val, list) or isinstance(val, tuple):
@@ -454,7 +454,7 @@ class miniflask():
     def stop_parse(self):
         self.halt_parse = True
 
-    def parse_args(self, argv=None, optional=True, fuzzy_args=True):
+    def parse_args(self, argv=None, optional=True, fuzzy_args=True):  # noqa: C901 too-complex
         if self.argparse_called:
             raise SystemError("The function `parse_args` has been called already. Did you maybe called `mf.parse_args()` and `mf.run()` in the same script? Solutions are:\n\t- Please use only one of those functions.\n\t- If you actually need both functions, please do not hesitate to write an issue on\n\t\thttps://github/da-h/miniflask/issues\n\t  to explain you used case.\n\t  (It's not hard to implement, but I need to know, if and when this functionality is needed. ;) )")
 

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -194,20 +194,20 @@ class miniflask():
     # get unique id of a moodule
     def getModuleId(self, module_id):
         module_ids = self.modules_avail.keys()
-        module = module_id.replace(".", "\.(.*\.)*")
+        module = module_id.replace(".", r"\.(.*\.)*")
 
         # first search for a default module
-        r = re.compile("^(.*\.)?%s(\..*)?\.(default|%s)$" % (module, module_id.split(".")[-1]))
+        r = re.compile(r"^(.*\.)?%s(\..*)?\.(default|%s)$" % (module, module_id.split(".")[-1]))
         found_modules = list(filter(r.match, module_ids))
 
         # if no default module found, check for direct identifier
         if len(found_modules) == 0:
-            r = re.compile("^(.*\.)?%s$" % module)
+            r = re.compile(r"^(.*\.)?%s$" % module)
             found_modules = list(filter(r.match, module_ids))
 
         # if no default module found, check for related identifier
         if len(found_modules) == 0:
-            r = re.compile("^(.*\.)?%s(\..*)?$" % module)
+            r = re.compile(r"^(.*\.)?%s(\..*)?$" % module)
             found_modules = list(filter(r.match, module_ids))
 
         # if more than one module found, exclude all low-priority modules
@@ -720,7 +720,7 @@ class miniflask():
                 raise
 
 
-relative_import_re = re.compile("(\.+)(.*)")
+relative_import_re = re.compile(r"(\.+)(.*)")
 
 
 class miniflask_wrapper(miniflask):

--- a/src/miniflask/modules/__init__.py
+++ b/src/miniflask/modules/__init__.py
@@ -1,8 +1,8 @@
 
 def registerPredefined(modules_avail):
     for m in ["modules", "events", "info", "settings"]:
-        module_name_id = 'miniflask.'+m
-        importpath = 'miniflask.modules.'+m
+        module_name_id = 'miniflask.' + m
+        importpath = 'miniflask.modules.' + m
         modules_avail[module_name_id] = {
             'id': module_name_id,
             'importpath': importpath,

--- a/src/miniflask/modules/events/__init__.py
+++ b/src/miniflask/modules/events/__init__.py
@@ -1,5 +1,4 @@
-from miniflask.dummy import miniflask_dummy
-from colored import fg, bg, attr
+from colored import fg, attr
 from miniflask.miniflask import highlight_module
 import re
 import typing

--- a/src/miniflask/modules/events/__init__.py
+++ b/src/miniflask/modules/events/__init__.py
@@ -76,7 +76,7 @@ def get_event_tree(state, event, eventname, event_tree={}, only_loaded=True):  #
         if (eventname, True) in state["events"]:
             modules += state["events"][(eventname, True)][0]
         for m in modules:
-            if not m in event._mf.modules_loaded:
+            if m not in event._mf.modules_loaded:
                 continue
             _fns.append(event[m][eventname])
     else:

--- a/src/miniflask/modules/events/__init__.py
+++ b/src/miniflask/modules/events/__init__.py
@@ -2,6 +2,7 @@ from colored import fg, attr
 from miniflask.miniflask import highlight_module
 import re
 import typing
+from dis import Bytecode
 
 
 def color_module(moduleid, short=False):
@@ -50,9 +51,6 @@ def register(mf):
 
 
 # adapted from https://stackoverflow.com/a/51904019
-from dis import Bytecode
-
-
 def list_func_calls(fn):
     funcs = []
     bytecode = Bytecode(fn)

--- a/src/miniflask/modules/events/__init__.py
+++ b/src/miniflask/modules/events/__init__.py
@@ -19,8 +19,6 @@ def register(mf):
     # precompute events
     events = {}
     for module_id in mf.modules_avail.keys():
-        module_path = mf.modules_avail[module_id]["importpath"]
-
         # ignore self
         if __name__ == mf.getModuleId(module_id):
             continue

--- a/src/miniflask/modules/events/__init__.py
+++ b/src/miniflask/modules/events/__init__.py
@@ -7,8 +7,8 @@ from dis import Bytecode
 
 def color_module(moduleid, short=False):
     moduleid = moduleid.split(".")
-    moduleid[0] = attr('dim')+moduleid[0]
-    moduleid[-1] = attr('reset')+highlight_module(moduleid[-1])
+    moduleid[0] = attr('dim') + moduleid[0]
+    moduleid[-1] = attr('reset') + highlight_module(moduleid[-1])
     if short:
         return moduleid[-1]
     return ".".join(moduleid)
@@ -28,12 +28,12 @@ def register(mf):
         # note all events
         module_events = mf.getModuleEvents(module_id)
         for e in module_events:
-            event_key = (e[0],e[1][0])
+            event_key = (e[0], e[1][0])
             if event_key in events:
                 events[event_key][0].append(module_id)
                 events[event_key][1].append(e[1][1])
             else:
-                events[event_key] = ([module_id],[e[1][1]])
+                events[event_key] = ([module_id], [e[1][1]])
 
     # register actual module
     mf.register_defaults({
@@ -56,16 +56,16 @@ def list_func_calls(fn):
     bytecode = Bytecode(fn)
     instrs = list(reversed([instr for instr in bytecode]))
     for (ix, instr) in enumerate(instrs):
-        if instr.argval == "event" and ix-2 > 0 and instrs[ix-1].opname == "LOAD_METHOD":
-            funcs.append(instrs[ix-1].argval)
-        elif instr.argval == "event" and ix-1 > 0 and instrs[ix-1].opname == "LOAD_ATTR" and instrs[ix-1].argval == "optional" and instrs[ix-2].opname == "LOAD_METHOD":
-            funcs.append(instrs[ix-2].argval)
-        elif instr.argval == "event" and ix-1 > 0 and instrs[ix-1].opname == "LOAD_ATTR" and instrs[ix-1].argval not in ["_mf"]:
-            if instrs[ix-1].argval == "optional":
+        if instr.argval == "event" and ix - 2 > 0 and instrs[ix - 1].opname == "LOAD_METHOD":
+            funcs.append(instrs[ix - 1].argval)
+        elif instr.argval == "event" and ix - 1 > 0 and instrs[ix - 1].opname == "LOAD_ATTR" and instrs[ix - 1].argval == "optional" and instrs[ix - 2].opname == "LOAD_METHOD":
+            funcs.append(instrs[ix - 2].argval)
+        elif instr.argval == "event" and ix - 1 > 0 and instrs[ix - 1].opname == "LOAD_ATTR" and instrs[ix - 1].argval not in ["_mf"]:
+            if instrs[ix - 1].argval == "optional":
                 if ix - 2 > 0:
-                    funcs.append(instrs[ix-2].argval)
+                    funcs.append(instrs[ix - 2].argval)
             else:
-                funcs.append(instrs[ix-1].argval)
+                funcs.append(instrs[ix - 1].argval)
     return ["%s" % funcname for funcname in reversed(funcs)]
 
 
@@ -73,25 +73,25 @@ def get_event_tree(state, event, eventname, event_tree={}, only_loaded=True):
     _fns = []
     if only_loaded:
         modules = []
-        if (eventname,False) in state["events"]:
-            modules += state["events"][(eventname,False)][0]
-        if (eventname,True) in state["events"]:
-            modules += state["events"][(eventname,True)][0]
+        if (eventname, False) in state["events"]:
+            modules += state["events"][(eventname, False)][0]
+        if (eventname, True) in state["events"]:
+            modules += state["events"][(eventname, True)][0]
         for m in modules:
             if not m in event._mf.modules_loaded:
                 continue
             _fns.append(event[m][eventname])
     else:
-        if (eventname,False) in state["events"]:
-            _fns += state["events"][(eventname,False)][1]
-        if (eventname,True) in state["events"]:
-            _fns += state["events"][(eventname,True)][1]
+        if (eventname, False) in state["events"]:
+            _fns += state["events"][(eventname, False)][1]
+        if (eventname, True) in state["events"]:
+            _fns += state["events"][(eventname, True)][1]
 
     fns = []
     for fn in _fns:
-        if isinstance(fn,type):
+        if isinstance(fn, type):
             for fname in dir(fn):
-                f = getattr(fn,fname)
+                f = getattr(fn, fname)
                 if fname.startswith("__") and fname.endswith("__") and fname != "__init__":
                     continue
                 if not callable(f) or type(f) == type:
@@ -114,48 +114,48 @@ def get_event_tree(state, event, eventname, event_tree={}, only_loaded=True):
             else:
                 # breakpoint()
                 # event_tree[s] = (subevents, subevents_tree)
-                (s1,s2,_) = event.get_event_tree(s, event_tree, only_loaded=only_loaded)
+                (s1, s2, _) = event.get_event_tree(s, event_tree, only_loaded=only_loaded)
                 event_tree[s] = (s1, s2)
-                subevents_tree.append((s1,s2))
+                subevents_tree.append((s1, s2))
     return subevents, subevents_tree, event_tree
 
 
-def print_event_tree(state,event,tree,full_tree,depth=0):
+def print_event_tree(state, event, tree, full_tree, depth=0):
     if depth == 0:
         print()
-        print(fg('yellow')+attr('underlined')+"Event-Calltree"+attr('reset'))
-    for name,subtree in zip(*tree):
+        print(fg('yellow') + attr('underlined') + "Event-Calltree" + attr('reset'))
+    for name, subtree in zip(*tree):
         unique_flag = ">"
-        print("   "*depth+fg('yellow')+unique_flag+' '+attr('reset')+name+attr('reset'))
+        print("   " * depth + fg('yellow') + unique_flag + ' ' + attr('reset') + name + attr('reset'))
         if subtree != True:
             if len(subtree) > 0:
-                print_event_tree(state,event,subtree,full_tree,depth+1)
+                print_event_tree(state, event, subtree, full_tree, depth + 1)
         else:
             if len(full_tree[name][1]) > 0:
-                print("   "*(depth+2)+attr('dim')+"as above"+attr('reset'))
+                print("   " * (depth + 2) + attr('dim') + "as above" + attr('reset'))
     if depth == 0:
-        print() 
+        print()
 
 
-def print_event_list(state,event):
+def print_event_list(state, event):
     print()
-    print(fg('yellow')+attr('underlined')+"Available events"+attr('reset'))
+    print(fg('yellow') + attr('underlined') + "Available events" + attr('reset'))
     event_list = state["events"].keys()
     if state["event"]:
-        r = re.compile(".*"+state["event"]+".*")
-        event_list = list(filter(lambda e: r.match(e[0]),event_list))
+        r = re.compile(".*" + state["event"] + ".*")
+        event_list = list(filter(lambda e: r.match(e[0]), event_list))
     if state["module"]:
         new_events = {}
-        r = re.compile(".*"+state["module"]+".*")
+        r = re.compile(".*" + state["module"] + ".*")
         for e in state["events"].keys():
             modules = list(filter(r.match, state["events"][e]))
             if len(modules) > 0:
                 new_events[e] = modules
         state["events"] = new_events
-        event_list = list(filter(lambda e: e in state["events"],event_list))
+        event_list = list(filter(lambda e: e in state["events"], event_list))
     for e in sorted(event_list):
         unique_flag = "!" if e[1] else ">"
-        print(fg('yellow')+unique_flag+' '+e[0]+attr('reset')+" used in "+", ".join([color_module(ev, short=not state["long"]) for ev in state["events"][e][0]])+attr('reset'))
+        print(fg('yellow') + unique_flag + ' ' + e[0] + attr('reset') + " used in " + ", ".join([color_module(ev, short=not state["long"]) for ev in state["events"][e][0]]) + attr('reset'))
     print()
 
 
@@ -163,7 +163,7 @@ def init(state, event):
 
     # print it
     if state["list"]:
-        print_event_list(state,event)
+        print_event_list(state, event)
     else:
-        event_names, event_subtrees, full_tree = event.get_event_tree('main',only_loaded=state["only_loaded"])
-        print_event_tree(state,event,[['main'],[(event_names,event_subtrees)]],full_tree)
+        event_names, event_subtrees, full_tree = event.get_event_tree('main', only_loaded=state["only_loaded"])
+        print_event_tree(state, event, [['main'], [(event_names, event_subtrees)]], full_tree)

--- a/src/miniflask/modules/events/__init__.py
+++ b/src/miniflask/modules/events/__init__.py
@@ -3,6 +3,7 @@ from miniflask.miniflask import highlight_module
 import re
 import typing
 
+
 def color_module(moduleid, short=False):
     moduleid = moduleid.split(".")
     moduleid[0] = attr('dim')+moduleid[0]
@@ -10,6 +11,7 @@ def color_module(moduleid, short=False):
     if short:
         return moduleid[-1]
     return ".".join(moduleid)
+
 
 def register(mf):
 
@@ -49,6 +51,8 @@ def register(mf):
 
 # adapted from https://stackoverflow.com/a/51904019
 from dis import Bytecode
+
+
 def list_func_calls(fn):
     funcs = []
     bytecode = Bytecode(fn)
@@ -117,6 +121,7 @@ def get_event_tree(state, event, eventname, event_tree={}, only_loaded=True):
                 subevents_tree.append((s1,s2))
     return subevents, subevents_tree, event_tree
 
+
 def print_event_tree(state,event,tree,full_tree,depth=0):
     if depth == 0:
         print()
@@ -132,6 +137,7 @@ def print_event_tree(state,event,tree,full_tree,depth=0):
                 print("   "*(depth+2)+attr('dim')+"as above"+attr('reset'))
     if depth == 0:
         print() 
+
 
 def print_event_list(state,event):
     print()
@@ -154,6 +160,7 @@ def print_event_list(state,event):
         print(fg('yellow')+unique_flag+' '+e[0]+attr('reset')+" used in "+", ".join([color_module(ev, short=not state["long"]) for ev in state["events"][e][0]])+attr('reset'))
     print()
 
+
 def init(state, event):
 
     # print it
@@ -162,4 +169,3 @@ def init(state, event):
     else:
         event_names, event_subtrees, full_tree = event.get_event_tree('main',only_loaded=state["only_loaded"])
         print_event_tree(state,event,[['main'],[(event_names,event_subtrees)]],full_tree)
-

--- a/src/miniflask/modules/events/__init__.py
+++ b/src/miniflask/modules/events/__init__.py
@@ -69,7 +69,7 @@ def list_func_calls(fn):
     return ["%s" % funcname for funcname in reversed(funcs)]
 
 
-def get_event_tree(state, event, eventname, event_tree={}, only_loaded=True):
+def get_event_tree(state, event, eventname, event_tree={}, only_loaded=True):  # noqa: C901 too-complex
     _fns = []
     if only_loaded:
         modules = []

--- a/src/miniflask/modules/info/__init__.py
+++ b/src/miniflask/modules/info/__init__.py
@@ -1,5 +1,3 @@
-import sys
-
 def register(mf):
     mf.load(["modules", "events", "settings"])
     mf.stop_parse()

--- a/src/miniflask/modules/modules/__init__.py
+++ b/src/miniflask/modules/modules/__init__.py
@@ -2,6 +2,7 @@ def showModules(state, event):
     event._mf.showModules(with_event=state.all["events"])
     print()
 
+
 def register(mf):
     mf.register_globals({
         "events": False

--- a/src/miniflask/modules/settings/__init__.py
+++ b/src/miniflask/modules/settings/__init__.py
@@ -4,6 +4,7 @@ from itertools import zip_longest
 from miniflask.miniflask import highlight_module, highlight_val, highlight_name, highlight_val_overwrite, like
 from colored import attr
 
+
 html_module = lambda x: x  # noqa: E731 no-lambda
 html_name = lambda x: x  # noqa: E731 no-lambda
 html_val = lambda x: x  # noqa: E731 no-lambda

--- a/src/miniflask/modules/settings/__init__.py
+++ b/src/miniflask/modules/settings/__init__.py
@@ -24,8 +24,8 @@ def listsettings(state, asciicodes=True):
     if len(state.all) == 0:
         return "No Settings available."
     maxklen = max(len(k) for k in state.all.keys())
-    text = "Folder│"+color_name("module")+"│"+color_module("variable")+(" "*(maxklen-22))+" = "+color_val("value")+linesep
-    text += "—"*(maxklen+8)+linesep if asciicodes else ''
+    text = "Folder│" + color_name("module") + "│" + color_module("variable") + (" " * (maxklen - 22)) + " = " + color_val("value") + linesep
+    text += "—" * (maxklen + 8) + linesep if asciicodes else ''
     for k, v in sorted(state.all.items()):
 
         # ignore state variables that are not registered for argument parsing
@@ -34,10 +34,10 @@ def listsettings(state, asciicodes=True):
 
         klen = len(k)
         korig = k
-        overwritten = v != (state.default[k].default if hasattr(state.default[k],'default') else state.default[k])
+        overwritten = v != (state.default[k].default if hasattr(state.default[k], 'default') else state.default[k])
         k = k.split(".")
         if len(k) > 1:
-            k_hidden = [" "*len(ki) if ki==ki2 and asciicodes else ki for ki,ki2 in zip_longest(k,last_k) if ki is not None]
+            k_hidden = [" " * len(ki) if ki == ki2 and asciicodes else ki for ki, ki2 in zip_longest(k, last_k) if ki is not None]
             last_k = k
             if k_hidden[-2] == "default":
                 k_hidden[-3] = color_name(k_hidden[-3])
@@ -48,10 +48,10 @@ def listsettings(state, asciicodes=True):
             k_hidden = k
             k_hidden[-1] = color_module(k_hidden[-1])
 
-        is_lambda = callable(state.default[korig]) and type(state.default[korig]) != type and type(state.default[korig]) != EnumMeta and not isinstance(state.default[korig],like)
-        value_str = attr_fn('dim')+"λ ⟶   "+attr_fn('reset')+str(state.default[korig].default) if is_lambda else state.default[korig].str(asciicodes=False) if hasattr(state.default[korig],'str') else str(state.default[korig])
-        append = "" if not overwritten else " ⟶   "+color_val_overwrite(str(v))
-        text += "│".join(k_hidden)+(" "*(maxklen-klen))+" = "+color_val(value_str)+append+linesep
+        is_lambda = callable(state.default[korig]) and type(state.default[korig]) != type and type(state.default[korig]) != EnumMeta and not isinstance(state.default[korig], like)
+        value_str = attr_fn('dim') + "λ ⟶   " + attr_fn('reset') + str(state.default[korig].default) if is_lambda else state.default[korig].str(asciicodes=False) if hasattr(state.default[korig], 'str') else str(state.default[korig])
+        append = "" if not overwritten else " ⟶   " + color_val_overwrite(str(v))
+        text += "│".join(k_hidden) + (" " * (maxklen - klen)) + " = " + color_val(value_str) + append + linesep
 
     return text
 
@@ -63,10 +63,10 @@ def init(state):
 def settings_html(state):
     html = listsettings(state, asciicodes=False)
     html = html.split("\n")
-    html = "\n".join([h.replace('=','</td><td style="padding: 0 0.5em;">=</td><td><code>',1) for h in html])
-    html = html.replace('\n','</code></td></tr>\n<tr><td style="text-align:left;">')
+    html = "\n".join([h.replace('=', '</td><td style="padding: 0 0.5em;">=</td><td><code>', 1) for h in html])
+    html = html.replace('\n', '</code></td></tr>\n<tr><td style="text-align:left;">')
     html = html[:-8]
-    html = "<table><tr><td style='padding: 0 0.5em; font-weight: bold; text-align: left;'>"+html+"</table>"
+    html = "<table><tr><td style='padding: 0 0.5em; font-weight: bold; text-align: left;'>" + html + "</table>"
     return html
 
 

--- a/src/miniflask/modules/settings/__init__.py
+++ b/src/miniflask/modules/settings/__init__.py
@@ -4,10 +4,10 @@ from itertools import zip_longest
 from miniflask.miniflask import highlight_module, highlight_val, highlight_name, highlight_val_overwrite, like
 from colored import attr
 
-html_module = lambda x: x
-html_name= lambda x: x
-html_val = lambda x: x
-html_val_overwrite = lambda x: x
+html_module = lambda x: x  # noqa: E731 no-lambda
+html_name = lambda x: x  # noqa: E731 no-lambda
+html_val = lambda x: x  # noqa: E731 no-lambda
+html_val_overwrite = lambda x: x  # noqa: E731 no-lambda
 
 
 def listsettings(state, asciicodes=True):

--- a/src/miniflask/modules/settings/__init__.py
+++ b/src/miniflask/modules/settings/__init__.py
@@ -1,4 +1,3 @@
-import sys
 import os
 from enum import EnumMeta
 from itertools import zip_longest

--- a/src/miniflask/modules/settings/__init__.py
+++ b/src/miniflask/modules/settings/__init__.py
@@ -9,6 +9,7 @@ html_name= lambda x: x
 html_val = lambda x: x
 html_val_overwrite = lambda x: x
 
+
 def listsettings(state, asciicodes=True):
 
     # colors
@@ -57,6 +58,7 @@ def listsettings(state, asciicodes=True):
 
 def init(state):
     print(listsettings(state))
+
 
 def settings_html(state):
     html = listsettings(state, asciicodes=False)

--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -4,6 +4,7 @@ import re
 from .util import get_varid_from_fuzzy, highlight_module
 from .exceptions import StateKeyError
 
+
 class temporary_state(dict):
     def __init__(self, state, variables):
         self.variables = variables
@@ -27,7 +28,10 @@ class temporary_state(dict):
         for key in self.did_not_exist:
             del self.state[key]
 
+
 relative_import_re = re.compile("(\.+)(.*)")
+
+
 class state(dict):
     def __init__(self, module_name, state, state_default):
         self.all = state
@@ -111,7 +115,6 @@ class state(dict):
 
         # cache for next use
         del self.all[found_varids[0]]
-
 
     def __getitem__(self, name):
 
@@ -219,6 +222,6 @@ class like:
         if not asciicodes:
             attr = lambda x: ''
         return attr('dim')+"'"+str(self.varname)+"' or '"+str(self.alt)+"' ⟶   "+attr('reset')+str(self.default)
+
     def __str__(self):
         return self.str()
-

--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -213,14 +213,14 @@ class like:
         global_varname = varname if scope is None else scope + "." + varname
         self.varname = scope_name + "." + varname if scope_name is not None else varname
         self.alt = alt
-        self.fn = lambda state, event: state[global_varname] if global_varname in state else alt
+        self.fn = lambda state, event: state[global_varname] if global_varname in state else alt  # noqa: E731 no-lambda
 
     def __call__(self, state, event):
         return self.fn(state, event)
 
     def str(self, asciicodes=True):
         if not asciicodes:
-            attr = lambda x: ''
+            attr = lambda x: ''  # noqa: E731 no-lambda
         return attr('dim') + "'" + str(self.varname) + "' or '" + str(self.alt) + "' ⟶   " + attr('reset') + str(self.default)
 
     def __str__(self):

--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -1,7 +1,7 @@
 import sys
-from colored import fg, bg, attr
+from colored import fg, attr
 import re
-from .util import get_varid_from_fuzzy, highlight_error, highlight_module
+from .util import get_varid_from_fuzzy, highlight_module
 from .exceptions import StateKeyError
 
 class temporary_state(dict):

--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -41,7 +41,7 @@ class state(dict):
         # self.temporary = temporary_state(self)
 
     def scope(self, module_name, local=False):
-        return state(self.module_id+"."+module_name if local else module_name, self.state, self.state_default)
+        return state(self.module_id + "." + module_name if local else module_name, self.state, self.state_default)
 
     def temporary(self, variables):
         return temporary_state(self, variables)
@@ -55,7 +55,7 @@ class state(dict):
         name = sys.intern(name)
 
         # check if is internal variable
-        module_name = self.module_id+"."+name
+        module_name = self.module_id + "." + name
         if module_name in self.all:
             self.fuzzy_names[name] = module_name
             return True
@@ -92,7 +92,7 @@ class state(dict):
         name = sys.intern(name)
 
         # check if is internal variable
-        module_name = self.module_id+"."+name
+        module_name = self.module_id + "." + name
         if module_name in self.all:
             del self.all[module_name]
             return
@@ -111,7 +111,7 @@ class state(dict):
 
         # no module found with both variants
         elif len(found_varids) == 0:
-            raise StateKeyError("Variable '%s' not known. (Module %s attempted to access this variable.)\n\nI tried the following interpretations:\n\t- as module variable: '%s'\n\t- as global Variable: '%s'\n\t- finally, I tried any ordered selection that contains the keys: [%s]." % (fg('green')+name+attr('reset'),highlight_module(self.module_id),fg('green')+module_name+attr('reset'),fg('green')+name+attr('reset'),', '.join("'"+fg('green')+n+attr('reset')+"'" for n in name.split("."))))
+            raise StateKeyError("Variable '%s' not known. (Module %s attempted to access this variable.)\n\nI tried the following interpretations:\n\t- as module variable: '%s'\n\t- as global Variable: '%s'\n\t- finally, I tried any ordered selection that contains the keys: [%s]." % (fg('green') + name + attr('reset'), highlight_module(self.module_id), fg('green') + module_name + attr('reset'), fg('green') + name + attr('reset'), ', '.join("'" + fg('green') + n + attr('reset') + "'" for n in name.split("."))))
 
         # cache for next use
         del self.all[found_varids[0]]
@@ -126,7 +126,7 @@ class state(dict):
         name = sys.intern(name)
 
         # check if is internal variable
-        module_name = self.module_id+"."+name
+        module_name = self.module_id + "." + name
         if module_name in self.all:
             self.fuzzy_names[name] = module_name
             return self.all[module_name]
@@ -145,7 +145,7 @@ class state(dict):
 
         # no module found with both variants
         elif len(found_varids) == 0:
-            raise StateKeyError("Variable '%s' not known. (Module %s attempted to access this variable.)\n\nI tried the following interpretations:\n\t- as module variable: '%s'\n\t- as global Variable: '%s'\n\t- finally, I tried any ordered selection that contains the keys: [%s]." % (fg('green')+name+attr('reset'),highlight_module(self.module_id),fg('green')+module_name+attr('reset'),fg('green')+name+attr('reset'),', '.join("'"+fg('green')+n+attr('reset')+"'" for n in name.split("."))))
+            raise StateKeyError("Variable '%s' not known. (Module %s attempted to access this variable.)\n\nI tried the following interpretations:\n\t- as module variable: '%s'\n\t- as global Variable: '%s'\n\t- finally, I tried any ordered selection that contains the keys: [%s]." % (fg('green') + name + attr('reset'), highlight_module(self.module_id), fg('green') + module_name + attr('reset'), fg('green') + name + attr('reset'), ', '.join("'" + fg('green') + n + attr('reset') + "'" for n in name.split("."))))
 
         # cache for next use
         self.fuzzy_names[found_varids[0]] = name
@@ -162,7 +162,7 @@ class state(dict):
         name = sys.intern(name)
 
         # check if is internal variable
-        module_name = self.module_id+"."+name
+        module_name = self.module_id + "." + name
         if module_name in self.all:
             self.fuzzy_names[name] = module_name
             self.all[module_name] = val
@@ -201,7 +201,7 @@ class state(dict):
             if upmodule == offset:
                 module_name = self.module_id + ("." + relative_module if relative_module else "")
             else:
-                module_name = ".".join(self.module_id.split(".")[:-upmodule+offset]) + ("." + relative_module if relative_module else "")
+                module_name = ".".join(self.module_id.split(".")[:-upmodule + offset]) + ("." + relative_module if relative_module else "")
             was_relative = True
         return module_name, was_relative
 
@@ -211,17 +211,17 @@ class like:
         if scope_name is None:
             scope_name = scope
         global_varname = varname if scope is None else scope + "." + varname
-        self.varname = scope_name+"."+varname if scope_name is not None else varname
+        self.varname = scope_name + "." + varname if scope_name is not None else varname
         self.alt = alt
-        self.fn = lambda state,event: state[global_varname] if global_varname in state else alt
+        self.fn = lambda state, event: state[global_varname] if global_varname in state else alt
 
     def __call__(self, state, event):
-        return self.fn(state,event)
+        return self.fn(state, event)
 
     def str(self, asciicodes=True):
         if not asciicodes:
             attr = lambda x: ''
-        return attr('dim')+"'"+str(self.varname)+"' or '"+str(self.alt)+"' ⟶   "+attr('reset')+str(self.default)
+        return attr('dim') + "'" + str(self.varname) + "' or '" + str(self.alt) + "' ⟶   " + attr('reset') + str(self.default)
 
     def __str__(self):
         return self.str()

--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -29,7 +29,7 @@ class temporary_state(dict):
             del self.state[key]
 
 
-relative_import_re = re.compile("(\.+)(.*)")
+relative_import_re = re.compile(r"(\.+)(.*)")
 
 
 class state(dict):

--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -68,7 +68,7 @@ class state(dict):
         # search for fuzzy global variable
         found_varids = get_varid_from_fuzzy(name, self.all.keys())
 
-         # if no matching varid found, alert user
+        # if no matching varid found, alert user
         if len(found_varids) > 1:
             raise StateKeyError("Variable-Identifier '%s' is not unique. Found %i variables:\n\t%s\n\n    Call:\n        %s" % (highlight_module(name), len(found_varids), "\n\t".join(found_varids), " ".join(name)))
 
@@ -105,7 +105,7 @@ class state(dict):
         # search for fuzzy global variable
         found_varids = get_varid_from_fuzzy(name, self.all.keys())
 
-         # if no matching varid found, alert user
+        # if no matching varid found, alert user
         if len(found_varids) > 1:
             raise StateKeyError("Variable-Identifier '%s' is not unique. Found %i variables:\n\t%s\n\n    Call:\n        %s" % (highlight_module(name), len(found_varids), "\n\t".join(found_varids), " ".join(name)))
 
@@ -139,7 +139,7 @@ class state(dict):
         # search for fuzzy global variable
         found_varids = get_varid_from_fuzzy(name, self.all.keys())
 
-         # if no matching varid found, alert user
+        # if no matching varid found, alert user
         if len(found_varids) > 1:
             raise StateKeyError("Variable-Identifier '%s' is not unique. Found %i variables:\n\t%s\n\n    Call:\n        %s" % (highlight_module(name), len(found_varids), "\n\t".join(found_varids), " ".join(name)))
 
@@ -177,7 +177,7 @@ class state(dict):
         # search for fuzzy global variable
         found_varids = get_varid_from_fuzzy(name, self.all.keys())
 
-         # if no matching varid found, alert user
+        # if no matching varid found, alert user
         if len(found_varids) > 1:
             raise StateKeyError("Variable-Identifier '%s' is not unique. Found %i variables:\n\t%s\n\n    Call:\n        %s" % (highlight_module(name), len(found_varids), "\n\t".join(found_varids), " ".join(name)))
 

--- a/src/miniflask/util.py
+++ b/src/miniflask/util.py
@@ -32,11 +32,13 @@ def getModulesAvail(module_dirs, f={}):
             }
     return f
 
+
 # coloring
 def highlight_loading_module(x):
     l = len(x)
     x = x.split(".")
     return fg('light_gray')+".".join(x[:-1])+("" if len(x) == 1 else ".") + attr('reset') + fg('green') + attr('bold') + x[-1] + attr('reset')
+
 
 highlight_error = lambda: fg('red') + attr('bold') + "Error:" + attr('reset') + " "
 highlight_name = lambda x: fg('blue') + attr('bold') + x + attr('reset')
@@ -53,6 +55,8 @@ highlight_val_overwrite = lambda x: fg('red') + attr('bold') + x + attr('reset')
 
 
 import argparse
+
+
 def str2bool(v):
     if isinstance(v, bool):
        return v
@@ -65,6 +69,8 @@ def str2bool(v):
 
 
 import re
+
+
 def get_varid_from_fuzzy(varid, varid_list):
         # check for direct match first
         r = re.compile("^(.*\.)?%s$" % varid)

--- a/src/miniflask/util.py
+++ b/src/miniflask/util.py
@@ -68,12 +68,12 @@ def str2bool(v):
 
 def get_varid_from_fuzzy(varid, varid_list):
     # check for direct match first
-    r = re.compile("^(.*\.)?%s$" % varid)
+    r = re.compile(r"^(.*\.)?%s$" % varid)
     found_varids = list(filter(r.match, varid_list))
 
     # if no matching varid found, check for fuzzy identifier
     if len(found_varids) == 0:
-        r = re.compile("^(.*\.)?%s$" % varid.replace(".", "\.(.*\.)*"))
+        r = re.compile(r"^(.*\.)?%s$" % varid.replace(".", r"\.(.*\.)*"))
         found_varids = list(filter(r.match, varid_list))
 
     # if more than one module found, use default module-variables

--- a/src/miniflask/util.py
+++ b/src/miniflask/util.py
@@ -37,7 +37,7 @@ def getModulesAvail(module_dirs, f={}):
 def highlight_loading_module(x):
     l = len(x)
     x = x.split(".")
-    return fg('light_gray')+".".join(x[:-1])+("" if len(x) == 1 else ".") + attr('reset') + fg('green') + attr('bold') + x[-1] + attr('reset')
+    return fg('light_gray') + ".".join(x[:-1]) + ("" if len(x) == 1 else ".") + attr('reset') + fg('green') + attr('bold') + x[-1] + attr('reset')
 
 
 highlight_error = lambda: fg('red') + attr('bold') + "Error:" + attr('reset') + " "

--- a/src/miniflask/util.py
+++ b/src/miniflask/util.py
@@ -59,7 +59,7 @@ import argparse
 
 def str2bool(v):
     if isinstance(v, bool):
-       return v
+        return v
     if v.lower() in ('yes', 'true', 't', 'y', '1'):
         return True
     elif v.lower() in ('no', 'false', 'f', 'n', '0'):
@@ -72,20 +72,20 @@ import re
 
 
 def get_varid_from_fuzzy(varid, varid_list):
-        # check for direct match first
-        r = re.compile("^(.*\.)?%s$" % varid)
+    # check for direct match first
+    r = re.compile("^(.*\.)?%s$" % varid)
+    found_varids = list(filter(r.match, varid_list))
+
+    # if no matching varid found, check for fuzzy identifier
+    if len(found_varids) == 0:
+        r = re.compile("^(.*\.)?%s$" % varid.replace(".", "\.(.*\.)*"))
         found_varids = list(filter(r.match, varid_list))
 
-        # if no matching varid found, check for fuzzy identifier
-        if len(found_varids) == 0:
-            r = re.compile("^(.*\.)?%s$" % varid.replace(".","\.(.*\.)*"))
-            found_varids = list(filter(r.match, varid_list))
+    # if more than one module found, use default module-variables
+    if len(found_varids) > 1:
+        found_varids = list(filter(lambda x: "default." in x, found_varids))
 
-        # if more than one module found, use default module-variables
-        if len(found_varids) > 1:
-            found_varids = list(filter(lambda x: "default." in x, found_varids))
-
-        return found_varids
+    return found_varids
 
 
 # Argparse action for handling Enums

--- a/src/miniflask/util.py
+++ b/src/miniflask/util.py
@@ -8,15 +8,15 @@ def getModulesAvail(module_dirs, f={}):
     for base_module_name, dir in module_dirs.items():
         basename_dir = path.basename(dir)
         for (dirpath, dirnames, filenames) in walk(dir):
-            module_name_id = base_module_name+"."+dirpath[len(dir)+1:].replace(path.sep,".")
-            import_path = ((basename_dir+".") if not basename_dir.endswith('.') else "") +dirpath[len(dir)+1:].replace(path.sep,".")
+            module_name_id = base_module_name + "." + dirpath[len(dir) + 1:].replace(path.sep, ".")
+            import_path = ((basename_dir + ".") if not basename_dir.endswith('.') else "") + dirpath[len(dir) + 1:].replace(path.sep, ".")
 
             # empty module id is not allowed
             if len(module_name_id) == 0:
                 continue
 
             # ignore sub directories
-            if path.exists(path.join(dirpath,".ignoredir")) or (path.basename(dirpath).startswith(".") and not dirpath.endswith('.')):
+            if path.exists(path.join(dirpath, ".ignoredir")) or (path.basename(dirpath).startswith(".") and not dirpath.endswith('.')):
                 dirnames[:] = []
                 continue
 
@@ -27,7 +27,7 @@ def getModulesAvail(module_dirs, f={}):
             # module found
             f[module_name_id] = {
                 'id': module_name_id,
-                'lowpriority': path.exists(path.join(dirpath,".lowpriority")),
+                'lowpriority': path.exists(path.join(dirpath, ".lowpriority")),
                 'importpath': import_path
             }
     return f
@@ -36,20 +36,20 @@ def getModulesAvail(module_dirs, f={}):
 def highlight_loading_module(x):
     l = len(x)
     x = x.split(".")
-    return fg('light_gray')+".".join(x[:-1])+("" if len(x) == 1 else ".")+attr('reset')+fg('green')+attr('bold')+x[-1]+attr('reset')
+    return fg('light_gray')+".".join(x[:-1])+("" if len(x) == 1 else ".") + attr('reset') + fg('green') + attr('bold') + x[-1] + attr('reset')
 
-highlight_error = lambda: fg('red')+attr('bold')+"Error:"+attr('reset')+" "
-highlight_name = lambda x: fg('blue')+attr('bold')+x+attr('reset')
-highlight_module = lambda x: fg('green')+attr('bold')+x+attr('reset')
+highlight_error = lambda: fg('red') + attr('bold') + "Error:" + attr('reset') + " "
+highlight_name = lambda x: fg('blue') + attr('bold') + x + attr('reset')
+highlight_module = lambda x: fg('green') + attr('bold') + x + attr('reset')
 highlight_loading = lambda x: highlight_loading_module(x)
-highlight_loading_default = lambda y,x: attr('dim')+y+attr('reset')+" ⟶  "+highlight_loading_module(x)
-highlight_loaded_default = lambda y,x: attr('dim')+x+" found modules: "+", ".join(highlight_loading_module(m) for m in y)+attr('reset')
-highlight_loaded_none = lambda x: fg('red')+x+attr('reset')
-highlight_loaded = lambda x, y: attr('underlined')+x+attr('reset')+" "+fg('green')+attr('bold')+", ".join(y)+attr('reset')
-highlight_event = lambda x: fg('light_yellow')+x+attr('reset')
-highlight_type = lambda x: fg('cyan')+x+attr('reset')
+highlight_loading_default = lambda y, x: attr('dim') + y + attr('reset') + " ⟶  " + highlight_loading_module(x)
+highlight_loaded_default = lambda y, x: attr('dim') + x + " found modules: " + ", ".join(highlight_loading_module(m) for m in y) + attr('reset')
+highlight_loaded_none = lambda x: fg('red') + x + attr('reset')
+highlight_loaded = lambda x, y: attr('underlined') + x + attr('reset') + " " + fg('green') + attr('bold') + ", ".join(y) + attr('reset')
+highlight_event = lambda x: fg('light_yellow') + x + attr('reset')
+highlight_type = lambda x: fg('cyan') + x + attr('reset')
 highlight_val = lambda x: x
-highlight_val_overwrite = lambda x: fg('red')+attr('bold')+x+attr('reset')
+highlight_val_overwrite = lambda x: fg('red') + attr('bold') + x + attr('reset')
 
 
 import argparse

--- a/src/miniflask/util.py
+++ b/src/miniflask/util.py
@@ -37,7 +37,6 @@ def getModulesAvail(module_dirs, f={}):
 
 # coloring
 def highlight_loading_module(x):
-    l = len(x)
     x = x.split(".")
     return fg('light_gray') + ".".join(x[:-1]) + ("" if len(x) == 1 else ".") + attr('reset') + fg('green') + attr('bold') + x[-1] + attr('reset')
 

--- a/src/miniflask/util.py
+++ b/src/miniflask/util.py
@@ -1,6 +1,8 @@
 from os import walk, path
 from colored import attr, fg
 from argparse import Action
+import argparse
+import re
 
 
 # get modules in a directory
@@ -54,9 +56,6 @@ highlight_val = lambda x: x
 highlight_val_overwrite = lambda x: fg('red') + attr('bold') + x + attr('reset')
 
 
-import argparse
-
-
 def str2bool(v):
     if isinstance(v, bool):
         return v
@@ -66,9 +65,6 @@ def str2bool(v):
         return False
     else:
         raise argparse.ArgumentTypeError('Boolean value expected.')
-
-
-import re
 
 
 def get_varid_from_fuzzy(varid, varid_list):

--- a/src/miniflask/util.py
+++ b/src/miniflask/util.py
@@ -102,7 +102,7 @@ class EnumAction(Action):
         else:
             try:
                 enum = self._enum[values.upper()]
-            except:
+            except:  # noqa: E722
                 enum = self._enum(values)
             if return_enum:
                 return enum

--- a/src/miniflask/util.py
+++ b/src/miniflask/util.py
@@ -1,7 +1,7 @@
-from os import walk, path, linesep
+from os import walk, path
 from colored import attr, fg
 from argparse import Action
-from enum import Enum
+
 
 # get modules in a directory
 def getModulesAvail(module_dirs, f={}):

--- a/tests/enums/main.py
+++ b/tests/enums/main.py
@@ -1,8 +1,8 @@
 import sys
 import os
-sys.path.insert(0, os.path.join("..","..","src"))
+sys.path.insert(0, os.path.join("..", "..", "src"))
 
-import miniflask
+import miniflask  # noqa: E402
 mf = miniflask.init(
     module_dirs="./modules",
 )

--- a/tests/enums/modules/module1/__init__.py
+++ b/tests/enums/modules/module1/__init__.py
@@ -9,6 +9,7 @@ class SIZE(Enum):
 
 
 def main(state, event):
+    del event  # unused
     print("size :", state["size"].name)
     print("sizerequired:", state["sizerequired"].name)
     print("sizelist:", str(" ".join(s.name for s in state["sizelist"])))

--- a/tests/enums/modules/module1/__init__.py
+++ b/tests/enums/modules/module1/__init__.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class SIZE(Enum):
     # The integer values define their order in a tensor
     SMALL = 0
@@ -11,6 +12,7 @@ def main(state, event):
     print("size :", state["size"].name)
     print("sizerequired:", state["sizerequired"].name)
     print("sizelist:", str(" ".join(s.name for s in state["sizelist"])))
+
 
 def register(mf):
     mf.register_defaults({

--- a/tests/exception_event/main.py
+++ b/tests/exception_event/main.py
@@ -1,8 +1,8 @@
 import sys
 import os
-sys.path.insert(0, os.path.join("..","..","src"))
+sys.path.insert(0, os.path.join("..", "..", "src"))
 
-import miniflask
+import miniflask  # noqa: E402
 mf = miniflask.init(
     module_dirs="./modules",
 )

--- a/tests/exception_event/modules/module1/__init__.py
+++ b/tests/exception_event/modules/module1/__init__.py
@@ -2,5 +2,6 @@
 def main(state, event):
     raise ValueError("Throwing an Exception.")
 
+
 def register(mf):
     mf.register_event('main', main)

--- a/tests/exception_register/main.py
+++ b/tests/exception_register/main.py
@@ -1,8 +1,8 @@
 import sys
 import os
-sys.path.insert(0, os.path.join("..","..","src"))
+sys.path.insert(0, os.path.join("..", "..", "src"))
 
-import miniflask
+import miniflask  # noqa: E402
 mf = miniflask.init(
     module_dirs="./modules",
 )

--- a/tests/features/modules/a/__init__.py
+++ b/tests/features/modules/a/__init__.py
@@ -2,16 +2,17 @@
 def test():
     print("test")
 
+
 def main(state, event):
     print(event.test.modules)
     print(event.test.fns)
     print(event["modules.a"])
     print(event.optional["modules.a"])
     print(event.optional.test())
-    # print(event.optional.test(altfn=lambda x:x))
+
 
 def register(mf):
     mf.load_as_child('b')
-    mf.register_defaults({"test":42})
+    mf.register_defaults({"test": 42})
     mf.register_event('test', test, unique=True)
     mf.register_event('main', main)

--- a/tests/features/modules/a/__init__.py
+++ b/tests/features/modules/a/__init__.py
@@ -4,6 +4,7 @@ def test():
 
 
 def main(state, event):
+    del state  # unused
     print(event.test.modules)
     print(event.test.fns)
     print(event["modules.a"])

--- a/tests/features/modules/b/__init__.py
+++ b/tests/features/modules/b/__init__.py
@@ -1,9 +1,11 @@
 
 def test(state):
+    del state  # unused
     print("test")
 
 
 def main(state, event):
+    del state  # unused
     print(event.test.modules)
     print(event.test.fns)
     print(event["modules.a"])

--- a/tests/features/modules/b/__init__.py
+++ b/tests/features/modules/b/__init__.py
@@ -2,13 +2,15 @@
 def test(state):
     print("test")
 
+
 def main(state, event):
     print(event.test.modules)
     print(event.test.fns)
     print(event["modules.a"])
     print(event.optional["modules.a"])
 
+
 def register(mf):
-    mf.register_defaults({"test_b":42})
+    mf.register_defaults({"test_b": 42})
     mf.register_event('test', test, unique=False)
     mf.register_event('main', main)

--- a/tests/features/test_features.py
+++ b/tests/features/test_features.py
@@ -1,8 +1,8 @@
 import sys
 import os
-sys.path.insert(0, os.path.join("..","..","src"))
+sys.path.insert(0, os.path.join("..", "..", "src"))
 
-import miniflask
+import miniflask  # noqa: E402
 mf = miniflask.init(
     module_dirs="./modules",
 )

--- a/tests/outervar/mf_event.py
+++ b/tests/outervar/mf_event.py
@@ -3,7 +3,7 @@ import sys
 import os
 sys.path.insert(0, os.path.join("..", "..", "src"))
 
-import miniflask
+import miniflask  # noqa: E402
 mf = miniflask.init(
     module_dirs="./modules",
 )

--- a/tests/outervar/mf_event.py
+++ b/tests/outervar/mf_event.py
@@ -1,7 +1,7 @@
 #!/bin/python
 import sys
 import os
-sys.path.insert(0, os.path.join("..","..","src"))
+sys.path.insert(0, os.path.join("..", "..", "src"))
 
 import miniflask
 mf = miniflask.init(
@@ -12,4 +12,3 @@ mf.load("module1")
 
 varA = 42
 mf.event.main()
-

--- a/tests/outervar/modules/module1/__init__.py
+++ b/tests/outervar/modules/module1/__init__.py
@@ -2,6 +2,7 @@ from miniflask import outervar
 
 
 def main(state, event, varA=outervar):
+    del state, event  # unused
     print("outervar:", varA)
 
 

--- a/tests/outervar/modules/module1/__init__.py
+++ b/tests/outervar/modules/module1/__init__.py
@@ -1,7 +1,9 @@
 from miniflask import outervar
 
+
 def main(state, event, varA=outervar):
-    print("outervar:",varA)
+    print("outervar:", varA)
+
 
 def register(mf):
     mf.register_event('main', main, unique=True)

--- a/tests/speedtest/mf_class.py
+++ b/tests/speedtest/mf_class.py
@@ -1,19 +1,21 @@
 #!/bin/python
 import sys
 import os
-sys.path.insert(0, os.path.join("..","..","src"))
+sys.path.insert(0, os.path.join("..", "..", "src"))
 
-import miniflask
+import miniflask  # noqa: E402
 mf = miniflask.init(
     module_dirs="./modules",
 )
 mf.load("moduleunique")
+
 
 class event():
 
     @classmethod
     def func(cls, x):
         return x
+
 
 a = 0
 for i in range(10000000):

--- a/tests/speedtest/mf_event.py
+++ b/tests/speedtest/mf_event.py
@@ -1,9 +1,9 @@
 #!/bin/python
 import sys
 import os
-sys.path.insert(0, os.path.join("..","..","src"))
+sys.path.insert(0, os.path.join("..", "..", "src"))
 
-import miniflask
+import miniflask  # noqa: E402
 mf = miniflask.init(
     module_dirs="./modules",
 )

--- a/tests/speedtest/mf_event_nomfargs.py
+++ b/tests/speedtest/mf_event_nomfargs.py
@@ -1,9 +1,9 @@
 #!/bin/python
 import sys
 import os
-sys.path.insert(0, os.path.join("..","..","src"))
+sys.path.insert(0, os.path.join("..", "..", "src"))
 
-import miniflask
+import miniflask  # noqa: E402
 mf = miniflask.init(
     module_dirs="./modules",
 )

--- a/tests/speedtest/mf_event_nonunique.py
+++ b/tests/speedtest/mf_event_nonunique.py
@@ -1,9 +1,9 @@
 #!/bin/python
 import sys
 import os
-sys.path.insert(0, os.path.join("..","..","src"))
+sys.path.insert(0, os.path.join("..", "..", "src"))
 
-import miniflask
+import miniflask  # noqa: E402
 mf = miniflask.init(
     module_dirs="./modules",
 )

--- a/tests/speedtest/mf_python.py
+++ b/tests/speedtest/mf_python.py
@@ -1,17 +1,19 @@
 #!/bin/python
 import sys
 import os
-sys.path.insert(0, os.path.join("..","..","src"))
+sys.path.insert(0, os.path.join("..", "..", "src"))
 
-import miniflask
+import miniflask  # noqa: E402
 mf = miniflask.init(
     module_dirs="./modules",
 )
 mf.load("module1")
-from modules.module1 import func as func2
+from modules.module1 import func as func2  # noqa: F401,E402
+
 
 def func(x):
     return x
+
 
 a = 0
 for i in range(10000000):

--- a/tests/speedtest/mf_state.py
+++ b/tests/speedtest/mf_state.py
@@ -1,9 +1,9 @@
 #!/bin/python
 import sys
 import os
-sys.path.insert(0, os.path.join("..","..","src"))
+sys.path.insert(0, os.path.join("..", "..", "src"))
 
-import miniflask
+import miniflask  # noqa: E402
 mf = miniflask.init(
     module_dirs="./modules",
 )

--- a/tests/speedtest/mf_state_fuzzy.py
+++ b/tests/speedtest/mf_state_fuzzy.py
@@ -1,9 +1,9 @@
 #!/bin/python
 import sys
 import os
-sys.path.insert(0, os.path.join("..","..","src"))
+sys.path.insert(0, os.path.join("..", "..", "src"))
 
-import miniflask
+import miniflask  # noqa: E402
 mf = miniflask.init(
     module_dirs="./modules",
 )

--- a/tests/speedtest/modules/modulenomfargs/__init__.py
+++ b/tests/speedtest/modules/modulenomfargs/__init__.py
@@ -1,4 +1,5 @@
 def func(x, **kwargs):
+    del kwargs  # unused
     return x
 
 

--- a/tests/speedtest/modules/modulenomfargs/__init__.py
+++ b/tests/speedtest/modules/modulenomfargs/__init__.py
@@ -1,5 +1,6 @@
 def func(x, **kwargs):
     return x
 
+
 def register(mf):
     mf.register_event('func', func, unique=True)

--- a/tests/speedtest/modules/modulenonunique/__init__.py
+++ b/tests/speedtest/modules/modulenonunique/__init__.py
@@ -1,5 +1,6 @@
 def func(state, event, x):
     return x
 
+
 def register(mf):
     mf.register_event('func', func, unique=False)

--- a/tests/speedtest/modules/modulenonunique/__init__.py
+++ b/tests/speedtest/modules/modulenonunique/__init__.py
@@ -1,4 +1,5 @@
 def func(state, event, x):
+    del state, event  # unused
     return x
 
 

--- a/tests/speedtest/modules/moduleunique/__init__.py
+++ b/tests/speedtest/modules/moduleunique/__init__.py
@@ -1,8 +1,10 @@
 def func(state, event, x):
+    del state, event  # unused
     return x
 
 
 def before_func(state, event, *args, **kwargs):
+    del state, event  # unused
     return args, kwargs
 
 

--- a/tests/speedtest/modules/moduleunique/__init__.py
+++ b/tests/speedtest/modules/moduleunique/__init__.py
@@ -1,8 +1,10 @@
 def func(state, event, x):
     return x
 
+
 def before_func(state, event, *args, **kwargs):
     return args, kwargs
+
 
 def register(mf):
     mf.register_event('func', func, unique=True, call_before_after=True)

--- a/tests/speedtest/python.py
+++ b/tests/speedtest/python.py
@@ -3,6 +3,7 @@
 def func():
     return 42
 
+
 a = 0
 for i in range(10000000):
     a += func()

--- a/tests/temporary/main.py
+++ b/tests/temporary/main.py
@@ -1,6 +1,4 @@
-import sys
-import os
-
 import miniflask
+
 mf = miniflask.init("modules")
 mf.run()

--- a/tests/temporary/modules/models/dosomething/__init__.py
+++ b/tests/temporary/modules/models/dosomething/__init__.py
@@ -1,9 +1,11 @@
 from miniflask.exceptions import StateKeyError
 
+
 def dosomething(state, event):
     print("in event: variable =", state["variable"])
     if "new_variable" in state:
         print("in event: new_variable =", state["new_variable"])
+
 
 def main(state, event):
 
@@ -37,6 +39,5 @@ def register(mf):
     mf.register_defaults({
         "variable": 0
     })
-    mf.register_event('dosomething',dosomething)
-    mf.register_event('main',main)
-
+    mf.register_event('dosomething', dosomething)
+    mf.register_event('main', main)

--- a/tests/temporary/modules/models/dosomething/__init__.py
+++ b/tests/temporary/modules/models/dosomething/__init__.py
@@ -20,7 +20,7 @@ def main(state, event):
     print("after event", state["variable"])
 
     try:
-        state["new_variable"]
+        _ = state["new_variable"]
         print("variable 'new_variable' should not exist")
     except StateKeyError:
         pass
@@ -29,7 +29,7 @@ def main(state, event):
     }):
         event.dosomething()
     try:
-        state["new_variable"]
+        _ = state["new_variable"]
         print("variable 'new_variable' should not exist")
     except StateKeyError:
         pass

--- a/tests/temporary/modules/models/dosomething/__init__.py
+++ b/tests/temporary/modules/models/dosomething/__init__.py
@@ -2,6 +2,7 @@ from miniflask.exceptions import StateKeyError
 
 
 def dosomething(state, event):
+    del event  # unused
     print("in event: variable =", state["variable"])
     if "new_variable" in state:
         print("in event: new_variable =", state["new_variable"])

--- a/tests/used_case1/main.py
+++ b/tests/used_case1/main.py
@@ -1,6 +1,4 @@
-import sys
-import os
-
 import miniflask
+
 mf = miniflask.init("modules")
 mf.run()

--- a/tests/used_case1/modules/data/augment/__init__.py
+++ b/tests/used_case1/modules/data/augment/__init__.py
@@ -1,5 +1,6 @@
 
 def augment(state, event, ds):
+    del event  # unused
     return [state["fn"] + "("] + ds + [")"]
 
 

--- a/tests/used_case1/modules/data/augment/__init__.py
+++ b/tests/used_case1/modules/data/augment/__init__.py
@@ -1,6 +1,7 @@
 
 def augment(state, event, ds):
-    return [state["fn"]+"("]+ds+[")"]
+    return [state["fn"] + "("] + ds + [")"]
+
 
 def register(mf):
     mf.register_defaults({

--- a/tests/used_case1/modules/data/augment2/__init__.py
+++ b/tests/used_case1/modules/data/augment2/__init__.py
@@ -1,10 +1,12 @@
 from random import randrange
 
+
 def augment(state, event, ds):
     d = list(ds)
-    i = randrange(0,len(d))
+    i = randrange(0, len(d))
     d[i] = "·"
     return "".join(d)
+
 
 def register(mf):
     mf.register_defaults({

--- a/tests/used_case1/modules/data/augment2/__init__.py
+++ b/tests/used_case1/modules/data/augment2/__init__.py
@@ -2,6 +2,7 @@ from random import randrange
 
 
 def augment(state, event, ds):
+    del state, event  # unused
     d = list(ds)
     i = randrange(0, len(d))
     d[i] = "·"

--- a/tests/used_case1/modules/data/batches/__init__.py
+++ b/tests/used_case1/modules/data/batches/__init__.py
@@ -1,12 +1,13 @@
 from colored import fg
 
+
 def dataloader(state, event):
     ds = list(event.dataset())
-    for i in range(len(ds)//state["size"]):
-        batch = ds[i*state["size"]:(i+1)*state["size"]]
-        batch = event.optional.dataset_augment(batch, altfn=lambda x:x)
-        yield fg('blue')+"".join(batch)+fg('white')+" Batch N°"+str(i)+ " of "+str(state.all["modules.data.batches.size"])
-    # print(ds)
+    for i in range(len(ds) // state["size"]):
+        batch = ds[i * state["size"]:(i + 1) * state["size"]]
+        batch = event.optional.dataset_augment(batch, altfn=lambda x: x)
+        yield fg('blue') + "".join(batch) + fg('white') + " Batch N°" + str(i) + " of " + str(state.all["modules.data.batches.size"])
+
 
 def register(mf):
     mf.register_defaults({

--- a/tests/used_case1/modules/datasets/__init__.py
+++ b/tests/used_case1/modules/datasets/__init__.py
@@ -6,4 +6,3 @@ def register(mf):
     #     "num_runs": 2
     # }
     # mf.register_defaults(defaults)
-

--- a/tests/used_case1/modules/datasets/cifar10/__init__.py
+++ b/tests/used_case1/modules/datasets/cifar10/__init__.py
@@ -2,6 +2,7 @@
 def dataset(state, event):
     return "the_fabulous_cifar10_dataset"
 
+
 def register(mf):
     mf.register_helpers({
         "num_data": 24

--- a/tests/used_case1/modules/datasets/cifar10/__init__.py
+++ b/tests/used_case1/modules/datasets/cifar10/__init__.py
@@ -1,5 +1,6 @@
 
 def dataset(state, event):
+    del state, event  # unused
     return "the_fabulous_cifar10_dataset"
 
 

--- a/tests/used_case1/modules/datasets/imagenet/__init__.py
+++ b/tests/used_case1/modules/datasets/imagenet/__init__.py
@@ -1,5 +1,6 @@
 
 def dataset(state, event):
+    del state, event  # unused
     return "imagenet"
 
 

--- a/tests/used_case1/modules/datasets/imagenet/__init__.py
+++ b/tests/used_case1/modules/datasets/imagenet/__init__.py
@@ -2,5 +2,6 @@
 def dataset(state, event):
     return "imagenet"
 
+
 def register(mf):
     mf.register_event("dataset", dataset, unique=True)

--- a/tests/used_case1/modules/flavours/sotacifar10/__init__.py
+++ b/tests/used_case1/modules/flavours/sotacifar10/__init__.py
@@ -1,8 +1,7 @@
 
 def register(mf):
-    mf.load(["cifar10","batches","main_loop","augment"])
+    mf.load(["cifar10", "batches", "main_loop", "augment"])
     defaults = {
         "num_runs": 2
     }
     mf.register_defaults(defaults)
-

--- a/tests/used_case1/modules/loops/main_loop/__init__.py
+++ b/tests/used_case1/modules/loops/main_loop/__init__.py
@@ -1,9 +1,10 @@
 
 def loop(state, event):
     for i in range(state["epoch"]):
-        print("Epoch "+str(i+1))
+        print("Epoch " + str(i + 1))
         for b in event.dataloader():
             print(b)
+
 
 def register(mf):
     defaults = {


### PR DESCRIPTION
Using #31 this PR fixes various linting issues:

Amongst other things, these are ...
- whitespace
- unused imports
- unused variables
- if membeship `not in`
- `r`-strings for templates
- `del` unused arguments
- missing/too many newlines

and disables a few selected messages on selected lines.