### PR TITLE
Add `argv` argument to `run()` method.

### DIFF
--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -661,7 +661,7 @@ class miniflask():
         # mark this instance as run
         self.argparse_called = True
 
-    def run(self, modules=["settings"], call="main"):
+    def run(self, modules=["settings"], call="main", argv=None):
         try:
 
             self.print_heading("Loading Modules")
@@ -670,7 +670,7 @@ class miniflask():
             self.load(modules)
 
             # parse command line arguments & overwrite default parameters
-            self.parse_args()
+            self.parse_args(argv=argv)
 
             # check if all requested modules are loaded
             if not self.halt_parse:


### PR DESCRIPTION
This PR adds an argument `argv` (default: `None`) to the `run()` method to be able to pass command line arguments along.
Otherwise, command line arguments must be set via `sys.argv` which is not always a viable option (e.g. during tests).

The `run` method simply passes the `argv` variable to the `parse_args` method, which already has the option to receive arguments via the `argv` argument.
Therefore, backwards compatibility is given.