### PR TITLE
Fix custom arguments via `run(argv=...)`.

### DIFF
--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -481,7 +481,10 @@ class miniflask():
 
         # actually parse the input
         parser = ArgumentParser()
-        parser.add_argument('cmds', default='info', nargs=1 if not optional else "?")
+        parser.add_argument('cmds', nargs=1 if not optional else "?")
+        # modules can also be set with `run(modules=...)`, so `cmds` can be empty here
+        if len(argv) > 1 and argv[1].startswith('-'):
+            argv = argv[:1] + [None] + argv[1:]
         args = parser.parse_args(argv[1:2])
 
         # load modules

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -285,7 +285,7 @@ class miniflask():
         return None, ".".join(varid_list)
 
     # loads module (once)
-    def load(self, module_name, verbose=True, auto_query=True, loading_text=highlight_loading, as_id=None, bind_events=True):  # noqa: C901 too-complex  pylint: disable=too-many-statements
+    def load(self, module_name: str or List[str], verbose=True, auto_query=True, loading_text=highlight_loading, as_id=None, bind_events=True):  # noqa: C901 too-complex  pylint: disable=too-many-statements
 
         # load list of modules
         if isinstance(module_name, str) and "," in module_name:

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -633,12 +633,12 @@ class miniflask():
                 # if no matching varid found, check for fuzzy identifier
                 if len(found_varids) > 1:
                     argv[i] = highlight_module(argv[i])
-                    raise ValueError(highlight_error() + "Variable-Identifier '--%s' is not unique. Found %i variables:\n\t%s\n\n    Call:\n        %s" % (highlight_module(varid), len(found_varids), "\n\t".join(found_varids), " ".join(argv)))
+                    raise ValueError(highlight_error() + "Variable-Identifier '--%s' is not unique. Found %i variables:\n\t%s\n\n    Call:\n        %s" % (highlight_module(varid), len(found_varids), "\n\t".join(found_varids), " ".join([a if isinstance(a, str) else str(a) for a in argv])))
 
                 # no module found with both variants
                 if len(found_varids) == 0:
                     argv[i] = highlight_module(argv[i])
-                    raise ValueError(highlight_error() + "Variable '--%s' not known.\n\n    Call:\n       %s" % (highlight_module(varid), " ".join(argv)))
+                    raise ValueError(highlight_error() + "Variable '--%s' not known.\n\n    Call:\n       %s" % (highlight_module(varid), " ".join([a if isinstance(a, str) else str(a) for a in argv])))
 
                 varid = found_varids[0]
 

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -596,7 +596,7 @@ class miniflask():
             print_help = True
 
         # split --varname=value expressions
-        argv = [v for val in argv for v in (val.split("=", 1) if val.startswith("--") or val.startswith("-") and not val[1:].isnumeric() else [val])]
+        argv = [v for val in argv for v in (val.split("=", 1) if val is not None and (val.startswith("--") or val.startswith("-")) and not val[1:].isnumeric() else [val])]
 
         # remember varids from user-args & fuzzy matching the settings
         user_varids = {}

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -601,6 +601,8 @@ class miniflask():
         # remember varids from user-args & fuzzy matching the settings
         user_varids = {}
         for i, varid in enumerate(argv):
+            if varid is None:
+                continue
             if not varid.startswith("--"):
                 if varid.startswith("-") and not varid[1:].replace('.', '', 1).isdigit():
                     varid = argv[i] = "-" + argv[i]


### PR DESCRIPTION
@da-h can you pleasy elaborate on why `val[1:].isnumeric()` is needed, and why `val.isnumeric()` is not used here?

- Only split argument expression, if it is not None.
- Fix errors when `argv` contains `None` values.