### PR TITLE
Dynamic Event Registration

### DIFF
--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -896,6 +896,12 @@ class miniflask_wrapper(miniflask):
         self._defined_events[name] = fn
         super().register_event(name, fn, **kwargs)
 
+    # overwrite event definition
+    def overwrite_event(self, name, fn, **kwargs):
+        self._delete_event(name, only_cache=False)
+        self._defined_events[name] = fn
+        super().register_event(name, fn, **kwargs)
+
     # overwrite state defaults
     def register_defaults(self, defaults, scope=None, **kwargs):
         # default behaviour is to use current module-name

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -880,25 +880,25 @@ class miniflask_wrapper(miniflask):
         # call load (but ensure no querying is made if relative imports were given)
         super().load(module_name, auto_query=auto_query, verbose=False, as_id=as_id, **kwargs)
 
-    def _delete_event(self, name, only_cache):
+    def unregister_event(self, name, only_cache):
         if hasattr(self.event, name):
             delattr(self.event, name)
         if not only_cache and name in self.event_objs:
             del self.event_objs[name]
         if "before_" + name in self.event_objs:
-            self._delete_event("before_" + name, only_cache)
+            self.unregister_event("before_" + name, only_cache)
         if "after_" + name in self.event_objs:
-            self._delete_event("after_" + name, only_cache)
+            self.unregister_event("after_" + name, only_cache)
 
     # define event
     def register_event(self, name, fn, **kwargs):
-        self._delete_event(name, only_cache=True)
+        self.unregister_event(name, only_cache=True)
         self._defined_events[name] = fn
         super().register_event(name, fn, **kwargs)
 
     # overwrite event definition
     def overwrite_event(self, name, fn, **kwargs):
-        self._delete_event(name, only_cache=False)
+        self.unregister_event(name, only_cache=False)
         self._defined_events[name] = fn
         super().register_event(name, fn, **kwargs)
 

--- a/tests/test_event/miniflask
+++ b/tests/test_event/miniflask
@@ -1,0 +1,1 @@
+../../src/miniflask

--- a/tests/test_event/modules/register_event_during_event/__init__.py
+++ b/tests/test_event/modules/register_event_during_event/__init__.py
@@ -1,0 +1,21 @@
+
+def test(i):
+    print("test", i)
+
+
+def add_test(mf):
+    def add_test_print(i):
+        print("added to test", i)
+    mf.register_event("test", add_test_print)
+
+
+def main(event):
+    event.test(0)
+    event.add_test()
+    event.test(1)
+
+
+def register(mf):
+    mf.register_event("test", test)
+    mf.register_event("add_test", add_test)
+    mf.register_event("main", main)

--- a/tests/test_event/test_register_event_during_event.py
+++ b/tests/test_event/test_register_event_during_event.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import miniflask  # noqa: E402
+
+
+def init_mf():
+    return miniflask.init(module_dirs=str(Path(__file__).parent / "modules"), debug=True)
+
+
+def test_register_event_during_event(capsys):
+    mf = init_mf()
+    mf.run(argv=[], modules=["register_event_during_event"])
+    captured = capsys.readouterr()
+    out = """
+test 0
+test 1
+added to test 1
+"""
+    assert out in captured.out


### PR DESCRIPTION
# Dynamic Event Registration
This PR enables any event to itself append to existing events or even overwriting existing events.

To accomplish this, this PR does the following:
- `mf` (the same object as is used during `register(mf)` to the list of possible arguments that are automatically determined and passed to an event upon execution
- `mf.overwrite_event` to redefine previous definitions completely
- `mf.register_event` clears the cache of the `event`-object automatically
- adds a simple test case for event registration during an event