### PR TITLE
added mf.any_child_loaded helper

### DIFF
--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -358,6 +358,7 @@ class miniflask():
         module_name = module_name if as_id is None else as_id
         mod.miniflask_obj = miniflask_wrapper(module_name, self)
         mod.miniflask_obj.bind_events = bind_events
+        self.modules_loaded[module_name] = mod
 
         # first load all parents
         # (starting with root parent, specializing with every step)
@@ -370,7 +371,6 @@ class miniflask():
                     self.load(parent_module, verbose=False, auto_query=False, loading_text=loading_text, as_id=parent_as_id, bind_events=bind_events)
 
         # remember loaded modules
-        self.modules_loaded[module_name] = mod
         self._recently_loaded.append(mod)
 
         # register events

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -891,6 +891,10 @@ class miniflask_wrapper(miniflask):
             del kwargs["verbose"]
         super().load(module_name, verbose=False, auto_query=auto_query, as_id=as_id, **kwargs)
 
+    # checks if child modules are already loaded
+    def any_child_loaded(self):
+        return any(x for x in self.modules_loaded if re.search(self.module_id + r"\..*", x))
+
     # register default module that is loaded if none of glob is matched
     # (enables relative imports)
     def register_default_module(self, module, **kwargs):


### PR DESCRIPTION
Parent modules and relative module loading allows separating basic module behavior from specialized modules.
For instance, consider the module structure,
```
parent
parent.base
parent.child1
parent.child2
```
where each of the listed paths can be loaded by the user.
The intended behavior is to load `parent.base` in any case and let the user choose then between `child1` and `child2` as a specialized behavior.
This does already work.

However, if we want to define `parent` as a default choice of modules, (i.e. `child2`), if the user did not load any of the specializations him-/herself, auto loading of parents gets in the way.
In that case of loading `parent`, mf would load `parent.child2`. (works as intended)
In the chase of loading `parent.child1`, auto-loading would first load `parent` and that would load `parent.child2`, where the user would like to overwrite this default behavior.

To solve this problem this PR adds a helper method, `mf.any_child_loaded`.
The `parent` module requires the default behavior to be defined as follows:
```
register(mf):
    if not mf.any_child_loaded():
        mf.load(".child2")
```

