### PR TITLE
Return none in after event

### DIFF
--- a/src/miniflask/event.py
+++ b/src/miniflask/event.py
@@ -7,6 +7,10 @@ class outervar:  # pylint: disable=too-few-public-methods
     pass
 
 
+class no_result_given:  # pylint: disable=too-few-public-methods
+    pass
+
+
 @dataclass
 class event_obj:
     fn: Callable or List[Callable]
@@ -384,14 +388,14 @@ class event(dict):
 # this event object is used for every call of before_/after_ events to simplify their call api
 class eventCall:  # pylint: disable=R0903 (too-few-public-methods)
 
-    def __init__(self, ev, fn_name, args, kwargs, result=None):
+    def __init__(self, ev, fn_name, args, kwargs, result=no_result_given):
         self._ev = ev
         self.hook = {
             "name": fn_name,
             "args": list(args),
             "kwargs": kwargs
         }
-        if result is not None:
+        if result is not no_result_given:
             self.hook["result"] = result
 
     def __getattr__(self, name):

--- a/tests/event/beforeafter/modules/afterevent/__init__.py
+++ b/tests/event/beforeafter/modules/afterevent/__init__.py
@@ -1,6 +1,8 @@
 
 def after_dosomething(event):
     print("after_-event called")
+    if event.hook["result"] is None:
+        return
     event.hook["result"] *= 2
 
 

--- a/tests/event/beforeafter/modules/afterevent2/__init__.py
+++ b/tests/event/beforeafter/modules/afterevent2/__init__.py
@@ -1,6 +1,8 @@
 
 def after_dosomething_as_well(event):
     print("after_-event (2) called")
+    if event.hook["result"] is None:
+        return
     event.hook["result"] += 1
 
 

--- a/tests/event/beforeafter/modules/afterevent2_multiple/__init__.py
+++ b/tests/event/beforeafter/modules/afterevent2_multiple/__init__.py
@@ -1,6 +1,8 @@
 
 def after_dosomething(event):
     print("after_-event (2) called")
+    if event.hook["result"] is None:
+        return
     for i, _ in enumerate(event.hook["result"]):
         event.hook["result"][i] += (i + 1)
 

--- a/tests/event/beforeafter/modules/afterevent_multiple/__init__.py
+++ b/tests/event/beforeafter/modules/afterevent_multiple/__init__.py
@@ -1,6 +1,8 @@
 
 def after_dosomething(event):
     print("after_-event called")
+    if event.hook["result"] is None:
+        return
     for i, _ in enumerate(event.hook["result"]):
         event.hook["result"][i] *= i
 

--- a/tests/event/beforeafter/modules/setup_none_return/__init__.py
+++ b/tests/event/beforeafter/modules/setup_none_return/__init__.py
@@ -1,0 +1,14 @@
+
+# note that this function does not ask for any miniflask variables (state/event/mf)
+def dosomething(val):
+    print("event called with value: %i" % val)
+
+
+def main(event):
+    out = event.dosomething(42)
+    print("event returned value: %s" % str(out))
+
+
+def register(mf):
+    mf.register_event('dosomething', dosomething)
+    mf.register_event('main', main)

--- a/tests/event/beforeafter/test_beforeafter_none_return.py
+++ b/tests/event/beforeafter/test_beforeafter_none_return.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+import miniflask  # noqa: E402
+
+
+def test_beforeafter_setup_none_return(capsys):
+    mf = miniflask.init(
+        module_dirs=str(Path(__file__).parent / "modules"),
+        debug=True
+    )
+    mf.load("setup_none_return")
+    mf.parse_args([])
+    captured = capsys.readouterr()
+    mf.event.main()
+    captured = capsys.readouterr()
+    assert captured.out == """
+event called with value: 42
+event returned value: None
+""".lstrip()
+
+
+def test_beforeafter_before(capsys):
+    mf = miniflask.init(
+        module_dirs=str(Path(__file__).parent / "modules"),
+        debug=True
+    )
+    mf.load(["setup_none_return", "beforeevent", "beforeevent2"])
+    mf.parse_args([])
+    captured = capsys.readouterr()
+    mf.event.main()
+    captured = capsys.readouterr()
+    assert captured.out == """
+before_-event called
+before_-event (2) called
+event called with value: 85
+event returned value: None
+""".lstrip()
+
+
+def test_beforeafter_before_otherorder(capsys):
+    mf = miniflask.init(
+        module_dirs=str(Path(__file__).parent / "modules"),
+        debug=True
+    )
+    mf.load(["setup_none_return", "beforeevent2", "beforeevent"])
+    mf.parse_args([])
+    captured = capsys.readouterr()
+    mf.event.main()
+    captured = capsys.readouterr()
+    assert captured.out == """
+before_-event (2) called
+before_-event called
+event called with value: 86
+event returned value: None
+""".lstrip()
+
+
+def test_beforeafter_after(capsys):
+    mf = miniflask.init(
+        module_dirs=str(Path(__file__).parent / "modules"),
+        debug=True
+    )
+    mf.load(["setup_none_return", "afterevent", "afterevent2"])
+    mf.parse_args([])
+    captured = capsys.readouterr()
+    mf.event.main()
+    captured = capsys.readouterr()
+    assert captured.out == """
+event called with value: 42
+after_-event called
+after_-event (2) called
+event returned value: None
+""".lstrip()
+
+
+def test_beforeafter_after_otherorder(capsys):
+    mf = miniflask.init(
+        module_dirs=str(Path(__file__).parent / "modules"),
+        debug=True
+    )
+    mf.load(["setup_none_return", "afterevent2", "afterevent"])
+    mf.parse_args([])
+    captured = capsys.readouterr()
+    mf.event.main()
+    captured = capsys.readouterr()
+    assert captured.out == """
+event called with value: 42
+after_-event (2) called
+after_-event called
+event returned value: None
+""".lstrip()
+
+
+def test_beforeafter_all(capsys):
+    mf = miniflask.init(
+        module_dirs=str(Path(__file__).parent / "modules"),
+        debug=True
+    )
+    mf.load(["setup_none_return", "beforeevent", "beforeevent2", "afterevent", "afterevent2"])
+    mf.parse_args([])
+    captured = capsys.readouterr()
+    mf.event.main()
+    captured = capsys.readouterr()
+    assert captured.out == """
+before_-event called
+before_-event (2) called
+event called with value: 85
+after_-event called
+after_-event (2) called
+event returned value: None
+""".lstrip()


### PR DESCRIPTION
# Bugfix: Returinng `None` is not possible with after-events

## Description
This MR fixes #80 by specifying internally if the `eventCall` object given to the `before`/`after`-events get a return-value from the actual event.  
Before this MR, returning `None` was not possible in an event, when also registering an `after`-event, as that value was used internally to determine whether the `eventCall`-object is constructed with or without a return value in the event call stack.

## Things done in this MR
- Added a helper-class `no_result_given` that gets overwritten any time an actual event (in contrast to a hook) gets called.

**Check all before creating this PR**:
- [x] unit tests adapted / created

