### PR TITLE
Fix for new internal module loader

### DIFF
--- a/tests/module_loading/modules/modules_b
+++ b/tests/module_loading/modules/modules_b
@@ -1,0 +1,1 @@
+modules_b

--- a/tests/module_loading/modules_b
+++ b/tests/module_loading/modules_b
@@ -1,0 +1,1 @@
+modules

--- a/tests/module_loading/test_basic_import_dict.py
+++ b/tests/module_loading/test_basic_import_dict.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+import pytest
+import miniflask  # noqa: E402
+
+
+def init_mf():
+    return miniflask.init(module_dirs={"modules": str(Path(__file__).parent / "modules_b")}, debug=True)
+
+
+def test_shortid():
+    mf = init_mf()
+    mf.run(argv=[], modules=["module1"])
+    assert "modules.parentdir.module1" in mf.modules_loaded
+    assert len(mf.modules_loaded) == 1
+
+
+def test_partial_id():
+    mf = init_mf()
+    mf.run(argv=[], modules=["modules.module1"])
+    assert "modules.parentdir.module1" in mf.modules_loaded
+    assert len(mf.modules_loaded) == 1
+
+
+def test_partial_id_2():
+    mf = init_mf()
+    mf.run(argv=[], modules=["parentdir.module1"])
+    assert "modules.parentdir.module1" in mf.modules_loaded
+    assert len(mf.modules_loaded) == 1
+
+
+def test_full_id():
+    mf = init_mf()
+    mf.run(argv=[], modules=["modules.parentdir.module1"])
+    assert "modules.parentdir.module1" in mf.modules_loaded
+    assert len(mf.modules_loaded) == 1
+
+
+def test_shortid_error():
+    mf = init_mf()
+    with pytest.raises(ValueError) as excinfo:
+        mf.run(argv=[], modules=["module2"])
+        assert "is not unique" in str(excinfo.value)
+    assert len(mf.modules_loaded) == 0
+
+
+def test_partial_id_error():
+    mf = init_mf()
+    with pytest.raises(ValueError) as excinfo:
+        mf.run(argv=[], modules=["modules.module2"])
+        assert "is not unique" in str(excinfo.value)
+    assert len(mf.modules_loaded) == 0
+
+
+def test_partial_id_3():
+    mf = init_mf()
+    mf.run(argv=[], modules=["modules.otherdir.module2"])
+    assert "modules.otherdir.module2" in mf.modules_loaded
+    assert len(mf.modules_loaded) == 1
+
+
+def test_partial_id_4():
+    mf = init_mf()
+    mf.run(argv=[], modules=["modules.otherdir.module2"])
+    assert "modules.otherdir.module2" in mf.modules_loaded
+    assert len(mf.modules_loaded) == 1
+
+
+def test_partial_id_5():
+    mf = init_mf()
+    mf.run(argv=[], modules=["parentdir.module2"])
+    assert "modules.parentdir.module2" in mf.modules_loaded
+    assert len(mf.modules_loaded) == 1
+
+
+def test_partial_id_6():
+    mf = init_mf()
+    mf.run(argv=[], modules=["parentdir.module2"])
+    assert "modules.parentdir.module2" in mf.modules_loaded
+    assert len(mf.modules_loaded) == 1


### PR DESCRIPTION
# Bugfix for new #83 module import

This MR solves a bug introduced in #83, where a module repository could not have a different id from its directory name.

## Description
MR #83 changed the way modules are loaded into `sys.modules` (see MR for more details).
However, the change introduced a bug when defining module directories using dict-notation in `mf.init`.
When defining a module-repository where the specified id differs from the actual folder it is imported from.

## Things done in this MR
- Fixed the bug
- Added a test case for this scenario

**Check all before creating this PR**:
- [x] unit tests adapted / created

