### PR TITLE
Keep attached events

### DIFF
--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -1341,7 +1341,7 @@ class miniflask_wrapper(miniflask):
 
         super().register_default_module(module, **kwargs)
 
-    def unregister_event(self, name: str, only_cache: bool = False):
+    def unregister_event(self, name: str, only_cache: bool = False, keep_attached_events: bool = True):
         r"""
         Clears an event by name.
 
@@ -1350,14 +1350,15 @@ class miniflask_wrapper(miniflask):
         - `only_cache`:  
             - Setting to `True` means that the event cache will be cleared. Upon the next call of `event.name` the cache will be rebuild.
             - Setting to `False` means that the event cache will be cleared *and* the internal event objects will be removed as well. Upon the next call of `event.name` miniflask will not recognize the event anymore.
+        - `keep_attached_events`:  By default (`True`), all events that are called together with this event (`before_`/`after_`-events) are kept. Setting to `False` clears those as well.
         """  # noqa: W291
         if hasattr(self.event, name):
             delattr(self.event, name)
         if not only_cache and name in self.event_objs:
             del self.event_objs[name]
-        if "before_" + name in self.event_objs:
+        if not keep_attached_events and "before_" + name in self.event_objs:
             self.unregister_event("before_" + name, only_cache)
-        if "after_" + name in self.event_objs:
+        if not keep_attached_events and "after_" + name in self.event_objs:
             self.unregister_event("after_" + name, only_cache)
 
     # define event
@@ -1374,14 +1375,21 @@ class miniflask_wrapper(miniflask):
         super().register_event(name, fn, **kwargs)
 
     # overwrite event definition
-    def overwrite_event(self, name: str, fn, **kwargs):
+    def overwrite_event(self, name: str, fn, keep_attached_events: bool = True, **kwargs):
         r"""
         Unregister an existing event & redefine it using another function.
 
         **Note**:
         The main difference between this function and `register_event` is that this method clears the cache *and* removes the event internally, while `register_event` only clears the cache. (This is especially important if one uses non-unique events).
+
+        Args:
+        - `name`: The event to clear from the event object.
+        - `only_cache`:  
+            - Setting to `True` means that the event cache will be cleared. Upon the next call of `event.name` the cache will be rebuild.
+            - Setting to `False` means that the event cache will be cleared *and* the internal event objects will be removed as well. Upon the next call of `event.name` miniflask will not recognize the event anymore.
+        - `keep_attached_events`:  By default (`True`), all events that are called together with this event (`before_`/`after_`-events) are kept. Setting to `False` clears those as well.
         """  # noqa: W291
-        self.unregister_event(name, only_cache=False)
+        self.unregister_event(name, only_cache=False, keep_attached_events=keep_attached_events)
         self._defined_events[name] = fn
         super().register_event(name, fn, **kwargs)
 

--- a/tests/event/overwrite_event/modules/main_overwrite_with_attached/__init__.py
+++ b/tests/event/overwrite_event/modules/main_overwrite_with_attached/__init__.py
@@ -1,0 +1,7 @@
+
+def main():
+    print("overwritten main event and removed attached as well")
+
+
+def register(mf):
+    mf.overwrite_event('main', main, keep_attached_events=False)

--- a/tests/event/overwrite_event/modules/module1/__init__.py
+++ b/tests/event/overwrite_event/modules/module1/__init__.py
@@ -3,5 +3,15 @@ def main():
     print("main event")
 
 
+def before_main():
+    print("before main event")
+
+
+def after_main():
+    print("after main event")
+
+
 def register(mf):
     mf.register_event('main', main, unique=False)
+    mf.register_event('before_main', before_main, unique=False)
+    mf.register_event('after_main', after_main, unique=False)

--- a/tests/event/overwrite_event/test_overwrite_event.py
+++ b/tests/event/overwrite_event/test_overwrite_event.py
@@ -14,7 +14,9 @@ def test_overwrite_setup(capsys):
     mf.event.main()
     captured = capsys.readouterr()
     assert captured.out == """
+before main event
 main event
+after main event
 """.lstrip()
 
 
@@ -30,7 +32,9 @@ def test_overwrite(capsys):
     mf.event.main()
     captured = capsys.readouterr()
     assert captured.out == """
+before main event
 overwritten main event
+after main event
 """.lstrip()
 
 
@@ -48,7 +52,27 @@ def test_overwrite_during_event(capsys):
     mf.event.main()
     captured = capsys.readouterr()
     assert captured.out == """
+before main event
 main event
+after main event
 overwrites event during init-event
+before main event
 overwritten main event during event
+after main event
+""".lstrip()
+
+
+def test_overwrite_with_attached(capsys):
+    mf = miniflask.init(
+        module_dirs=str(Path(__file__).parent / "modules"),
+        debug=False
+    )
+
+    mf.load(["module1", "main_overwrite_with_attached"])
+    mf.parse_args([])
+    captured = capsys.readouterr()
+    mf.event.main()
+    captured = capsys.readouterr()
+    assert captured.out == """
+overwritten main event and removed attached as well
 """.lstrip()


### PR DESCRIPTION
# Keep attached events on overwriting
**Attention**: This is a breaking change.

This MR changes the way events are overwritten/redefined using `mf.unregister_event` or `mf.overwrite_event`.

## Description
By default, a call to any of the mentioned methods, all events of the given name are unregistered from miniflask (either only their function cache or any of their future uses), and also all events that are attached to the event to be changed.

A typical used-case, however is the transformation of events using other modules using `before_` and `after_` event hooks (attached events). With other words, replacing an event **should not** replace the hooks used to modify or inspect the calls when changing its function.

This MR thus, by default, keeps all attached events upon reregistration, but allows the user to remove all additional (typically) user-events as well.

## Things done in this MR
- added `keep_attached_events` to `mf.unregister_event` and `mf.overwrite_event`

**Check all before creating this PR**:
- [x] Documentation adapted
- [x] unit tests adapted / created
