### PR TITLE
Show variable definiton locations for [definitions] and on CLI-argument error

### DIFF
--- a/docs/06-Predefined-Modules/index.md
+++ b/docs/06-Predefined-Modules/index.md
@@ -74,6 +74,26 @@ $$
 
 ---
 
+
+### Module `definitions`
+This module extends `settings` by showing also the code-locations of the setting-definitions.
+
+**Example Output:**
+{.customsyntax}$$
+Folder│\title{module}│\literal{variable} = value
+—————————————————————————————
+data│\title{augment}│\literal{fn}       = transform
+    │               │                     definition in line 10 in file 'data/augment/__init__.py'
+    │\title{batches}│\literal{size}     = 4
+    │               │                     definition in line 10 in file 'data/augment/__init__.py'
+loops│\title{main_loop}│\literal{epoch} = 2
+     │                 │                  definition in line 42 in file 'loops/main_loop/__init__.py'
+--------------------------------------------------
+$$
+
+---
+
+
 ### Module `info`
 Calls `modules` and then `events`.  
 (Finishes the program afterwards.)

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -1026,7 +1026,14 @@ class miniflask():
             if self.state[variables[0]] is None:
                 missing_arguments.append(variables)
         if len(missing_arguments) > 0:
-            self.settings_parser.error(linesep + linesep.join(["The following argument is required: " + " or ".join(["--" + arg for arg in reversed(args)]) for args in missing_arguments]))
+            args_err_strs = []
+            for args in missing_arguments:
+                arg_err_str = "\t" + " or ".join([highlight_module("--" + arg) for arg in reversed(args)])
+                if args[0] in self._settings_parse_later:
+                    summary = self._settings_parse_later[args[0]][3][-3]
+                    arg_err_str += linesep + "\t  Defined in line %s in file '%s'." % (highlight_event(str(summary.lineno)), attr('dim') + summary.filename + attr('reset'))
+                args_err_strs.append(arg_err_str)
+            raise ValueError(("Missing CLI-arguments or unspecified variables during miniflask call." + linesep + linesep.join(args_err_strs)))
 
         # finally parse lambda-dependencies
         for varname, (val, cliargs, parsefn, caller_traceback, _mf) in self._settings_parse_later.items():

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -98,6 +98,7 @@ class miniflask():
         self._settings_parse_later = {}
         self._settings_parse_later_overwrites_list = []
         self._settings_parse_later_overwrites = {}
+        self._settings_parser_tracebacks = {}
         self.settings_parser_required_arguments = []
         self.default_modules = []
         self.bind_events = True
@@ -744,6 +745,11 @@ class miniflask():
                     self.state[varname] = val
 
                 self._settings_parse_later[varname] = (val, cliargs, parsefn, caller_traceback, self)
+
+            # save all tracebacks in case we need this information due to an error
+            if varname not in self._settings_parser_tracebacks:
+                self._settings_parser_tracebacks[varname] = []
+            self._settings_parser_tracebacks[varname].append(("overwrite" if overwrite else "definition", caller_traceback))
 
     def _settings_parser_add(self, varname, val, caller_traceback, nargs=None, default=None):  # noqa: C901 too-complex
 

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -1035,9 +1035,11 @@ class miniflask():
             args_err_strs = []
             for args in missing_arguments:
                 arg_err_str = "\t" + " or ".join([highlight_module("--" + arg) for arg in reversed(args)])
-                if args[0] in self._settings_parse_later:
-                    summary = self._settings_parse_later[args[0]][3][-3]
-                    arg_err_str += linesep + "\t  Defined in line %s in file '%s'." % (highlight_event(str(summary.lineno)), attr('dim') + summary.filename + attr('reset'))
+                if args[0] in self._settings_parser_tracebacks:
+                    for definition_type, caller_traceback in self._settings_parser_tracebacks[args[0]]:
+                        summary = next(filter(lambda t: not t.filename.endswith("miniflask/miniflask.py"), reversed(caller_traceback)))
+                        adj = (fg('blue') + "Defined" if definition_type == "definition" else fg('yellow') + "Overwritten") + attr('reset')
+                        arg_err_str += linesep + "\t  " + adj + " in line %s in file '%s'." % (highlight_event(str(summary.lineno)), attr('dim') + path.relpath(summary.filename) + attr('reset'))
                 args_err_strs.append(arg_err_str)
             raise ValueError(("Missing CLI-arguments or unspecified variables during miniflask call." + linesep + linesep.join(args_err_strs)))
 

--- a/src/miniflask/modules/__init__.py
+++ b/src/miniflask/modules/__init__.py
@@ -1,6 +1,6 @@
 
 def registerPredefined(modules_avail):
-    for m in ["modules", "events", "info", "settings"]:
+    for m in ["modules", "events", "info", "settings", "definitions"]:
         module_name_id = 'miniflask.' + m
         importname = 'miniflask.modules.' + m
         modules_avail[module_name_id] = {

--- a/src/miniflask/modules/definitions/__init__.py
+++ b/src/miniflask/modules/definitions/__init__.py
@@ -1,0 +1,6 @@
+
+def register(mf):
+    mf.load("settings")
+    mf.overwrite_globals({
+        "settings.show_registration_definitions": True
+    })

--- a/tests/argparse/required/test_argparse_required_types.py
+++ b/tests/argparse/required/test_argparse_required_types.py
@@ -1,6 +1,5 @@
+import re
 from pathlib import Path
-import pytest
-
 import miniflask  # noqa: E402
 
 mf = miniflask.init(
@@ -9,26 +8,57 @@ mf = miniflask.init(
 )
 
 
-def test_types(capsys):
+def escape_ansi(line):
+    ansi_escape = re.compile(r'(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]')
+    return ansi_escape.sub('', line)
+
+
+def test_types():
     mf.load("module1")
     error_message = """
-The following argument is required: --modules.module1.int1
-The following argument is required: --modules.module1.int2
-The following argument is required: --modules.module1.float1
-The following argument is required: --modules.module1.float2
-The following argument is required: --modules.module1.float3
-The following argument is required: --modules.module1.float4
-The following argument is required: --modules.module1.float5
-The following argument is required: --modules.module1.float6
-The following argument is required: --modules.module1.enum1
-The following argument is required: --modules.module1.str1
-The following argument is required: --modules.module1.str2
-The following argument is required: --modules.module1.str3
-""".strip()
-    with pytest.raises(SystemExit) as excinfo:
+    Missing CLI-arguments or unspecified variables during miniflask call.
+        --modules.module1.int1
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.int2
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.float1
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.float2
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.float3
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.float4
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.float5
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.float6
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.bool1
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.bool2
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.enum1
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.str1
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.str2
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+        --modules.module1.str3
+        Defined in line 38 in file 'modules/module1/__init__.py'.
+""".strip().split("\n")
+    try:
         mf.parse_args(argv=[])
-    captured = capsys.readouterr()
-    assert excinfo.value.args[0] == 2
+    except ValueError as excinfo:
+        errtext = escape_ansi(str(excinfo)).split("\n")
 
-    # we allow any order of the messages "The following argument is required ..."
-    assert all(message in captured.err for message in error_message.split("\n"))
+    assert len(error_message) == len(errtext)
+    for expected, error in zip(error_message, errtext):
+
+        # we ignore the folder from which pytest is run
+        # (this would change the relative file path of the error message)
+        if "'" in expected:
+            start, end = expected.strip().split("'", 1)
+            assert error.strip().startswith(start)
+            assert error.strip().endswith(end)
+        else:
+            assert error.strip() == expected.strip()


### PR DESCRIPTION
# show variable definition locations & `[definitions]` module
- This MR improves debugging for missing CLI-variables by showing all definition locations when the error occurs.
- Additionally, the `[definition]` module is an extension of `[settings]` to show the location definitions together with the settings used

**Check all before creating this PR**:
- [x] Documentation adapted

