### PR TITLE
mf: set_scope should set absoulte id (without repository base name)

### DIFF
--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -1224,9 +1224,7 @@ class miniflask_wrapper(miniflask):
         Args:
         - `new_module_name`: The prefix to use with any `state["var"]` call.
         """  # noqa: W291
-        new_module_name, was_relative = self._get_relative_module_id(new_module_name)
-        if not was_relative:
-            new_module_name = self.module_base + "." + new_module_name
+        new_module_name, _ = self._get_relative_module_id(new_module_name)
         self.module_id = new_module_name
         self.state.module_id = new_module_name
         return new_module_name


### PR DESCRIPTION
# Fix `set_scope` cannot set global id.

**Api-Change**: This MR reenables `set_scope` to define the global id of a module.

Previously, `mf.set_scope(name)` would prefix the name with the module repository id the module is defined in.
It was not possible to adapt the scope of another repository.
After this MR, any module can share the scope with any other module.

(Related to #79)