### PR TITLE
State using ABC base class

### DIFF
--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -1,5 +1,6 @@
 import sys
 import re
+from collections.abc import MutableMapping
 
 from colored import fg, attr
 
@@ -35,7 +36,7 @@ class temporary_state:
 relative_import_re = re.compile(r"(\.+)(.*)")
 
 
-class state(dict):
+class state(MutableMapping):
     def __init__(self, module_name, internal_state_dict, state_default):  # pylint: disable=super-init-not-called
         r"""!... is a local dict
         Global Variables, but Fancy. ;)
@@ -331,6 +332,12 @@ class state(dict):
     def __deepcopy__(self, memo):
         del memo
         return self
+
+    def __iter__(self):
+        return filter(lambda key: key.startswith(self.module_id), self.all)
+
+    def __len__(self):
+        return len(list(filter(lambda key: key.startswith(self.module_id), self.all)))
 
 
 def _create_excpetion_notfound(module_id, varid, name):

--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -7,7 +7,7 @@ from .util import get_varid_from_fuzzy, highlight_module, get_relative_id
 from .exceptions import StateKeyError
 
 
-class temporary_state(dict):
+class temporary_state:
     def __init__(self, _state, variables):
         self.variables = variables
         self.state = _state

--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -44,6 +44,9 @@ class state(MutableMapping):
         Every event gets called with a state-Object as its first argument.
         This is the modules **local** and **persistent** variable scope.
 
+        **Local dict**:
+        You can use this object like a persistent dict for all events defined in the same module.
+
         **Fuzzy matching**:  
         The module dict will use local variables first. If however, a variable does not exist locally, miniflask will look in the parent modules as well.
         See [fuzzy matching](./02-dict operations.md).
@@ -63,6 +66,9 @@ class state(MutableMapping):
             print()
             state["var"] *= 500
             print(state["var"])
+            print("This module uses", len(state), "variables.")
+            for key in state:
+                print("This module is using the variable", key)
 
         def register(mf):
             mf.register_defaults({

--- a/tests/state/temporary/modules/models/addingvariables/__init__.py
+++ b/tests/state/temporary/modules/models/addingvariables/__init__.py
@@ -1,0 +1,7 @@
+
+def register(mf):
+    mf.register_defaults({
+        "additional_variable1": 0,
+        "additional_variable2": 0,
+        "additional_variable3": 0
+    })

--- a/tests/state/temporary/modules/models/dosomething/__init__.py
+++ b/tests/state/temporary/modules/models/dosomething/__init__.py
@@ -1,3 +1,4 @@
+import pytest  # pylint: disable=import-error
 from miniflask.exceptions import StateKeyError
 
 
@@ -14,29 +15,49 @@ def main(state, event):
     del state["new_variable"]
 
     print("before event", state["variable"])
-    with state.temporary({
-        "variable": 42
-    }):
-        event.dosomething()
-    print("after event", state["variable"])
 
-    try:
+    # Check if global state iterator has all variables that we expect
+    assert len(state.all) == 4, "Found global Variables %i" % len(state.all)
+
+    # Check if local state iterator has all variables that we expect
+    assert len(state) == 1, "Found lokal Variables %i" % len(state)
+
+    # Checking if variable can be temporarily overwritten
+    with state.temporary({
+        "variable": 42,
+    }):
+        assert len(state) == 1, "Found Variables %i" % len(state)
+    print("after event", state["variable"])
+    assert len(state) == 1, "Found Variables %i" % len(state)
+
+    # Checking if variable can be temporarily defined
+    with pytest.raises(StateKeyError):
         _ = state["new_variable"]
         print("variable 'new_variable' should not exist")
-    except StateKeyError:
-        pass
     with state.temporary({
         "new_variable": 12345
     }):
+        assert len(state) == 2, "Found Variables %i" % len(state)
         event.dosomething()
-    try:
+    with pytest.raises(StateKeyError):
         _ = state["new_variable"]
         print("variable 'new_variable' should not exist")
-    except StateKeyError:
-        pass
+    assert len(state) == 1, "Found Variables %i" % len(state)
+
+    # Checking if iterating keys works as well
+    assert ",".join(iter(state)) == "modules.models.dosomething.variable", "Found variables:" + ",".join(iter(state))
+    with state.temporary({
+        "variable2": 42,
+        "variable3": 42,
+        "variable4": 42
+    }):
+        assert ", ".join(iter(state)) == "modules.models.dosomething.variable, modules.models.dosomething.variable2, modules.models.dosomething.variable3, modules.models.dosomething.variable4", "Found variables:" + ", ".join(iter(state))
+    print("after event", state["variable"])
+    assert ",".join(iter(state)) == "modules.models.dosomething.variable", "Found variables:" + ",".join(iter(state))
 
 
 def register(mf):
+    mf.load("addingvariables")
     mf.register_defaults({
         "variable": 0
     })


### PR DESCRIPTION
# Implemented State using ABC base class

This MR adapts the implementation of `state` to use python's ABC base classes instead of extending `dict`.
This change allows to iterate over the variables in a module.
```python
print("This module uses", len(state), "variables.")
for key in state:
    print("This module is using the variable", key)
```

## Description
Some dict-operations could not be used on `state` variables (see #71).
This MR solves this by letting `collections.abc.MutableMapping` check if any functions are missing for a complete dict-implementation.


## Things done in this MR
- derived `state` class from `MutableMapping`
- removed base class from `temporary_state` as it has never been used
- added unit tests to check for modules local dict-operations, like `iter(state)` and `len(state)`.

**Check all before creating this PR**:
- [x] Documentation adapted
- [x] unit tests adapted / created
