### PR TITLE
Remove Unneeded state.scope(...,local) Argument

### DIFF
--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -96,14 +96,13 @@ class state(dict):
         Working on multiple scopes.
 
         The default behaviour of state is to work on the local module variables of the module the state is defined in.
-        Working on multiple module variables is easily possible with this command.
+        Working on module variables of other modules is easily possible with this command.
 
         Returns:
         A new `state` variable bound to a given scope.
 
         Args:
         - `module_name`: The module id to use for the variable.
-        - `local`: Setting to `True` uses relative module identifiers, setting to `False` uses `module_name` as an unique module id/scope.
 
         Examples:
 

--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -91,7 +91,7 @@ class state(dict):
         self.fuzzy_names = {}
         # self.temporary = temporary_state(self)
 
-    def scope(self, module_name, local=False):
+    def scope(self, module_name):
         r"""
         Working on multiple scopes.
 
@@ -130,7 +130,7 @@ class state(dict):
         ```
         """  # noqa: W291
 
-        return state(self.module_id + "." + module_name if local else module_name, self.all, self.default)
+        return state(module_name, self.all, self.default)
 
     def temporary(self, variables):
         r"""


### PR DESCRIPTION
# Remove Unneeded `state.scope(...,local)` Argument
**Attention**: This is may be a breaking change.

This MR removes `state.scope(...,local)` argument. Reason for this is that this functionality has been made obsolete due to fuzzy variable matching, introduced in miniflask `v2`.

**Check all before creating this PR**:
- [x] Documentation adapted
- [ ] unit tests adapted / created **(there havn't been any unit-tests for this feature)**

