### PR TITLE
Replaced attached properties with hidden database

### DIFF
--- a/src/miniflask/event.py
+++ b/src/miniflask/event.py
@@ -109,6 +109,15 @@ class event(dict):
         - `event.optional.eventname(..., altfn=...)` treats the event like a `unique` event, but in case no event was defined, it uses altfn to parse the arguments.
         # .{.end}
 
+        # Internal Event Data
+        The `event` object contains a hidden `_data` dictionary that saves the information needed to construct the events from the actual code.
+        In more detail:
+        - `event._data[eventname]` contains the dictionary with all information required to construct the events
+        - `event._data[eventname]["modules"]`: list of modules that define the event `eventname`
+        - `event._data[eventname]["wrapped_event"]`: symlink to `event.eventname`
+        - `event._data[eventname]["wrapped_single_events"]`: list of all wrapped events in case of non-unique event `eventname`
+        - `event._data[eventname]["raw_functions"]`: list of all raw functions (as defined in code) in the modules given above (same order as in the modules list)
+        - `event._data[eventname]["raw_function_args"]`: the `mf`, `state` and `event` objects arguments needed for the raw functions
 
         ### Performance Note {.alert}
         Leaving the `event`, `state` and `mf` arguments out from an event function definition removes an extra function wrapper around every function. Thus, without them the time consumption should not differ at all from a normal function call.

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -1408,6 +1408,7 @@ class miniflask_wrapper(miniflask):
         """  # noqa: W291
         if hasattr(self.event, name):
             delattr(self.event, name)
+            del self.event._data[name]
         if not only_cache and name in self.event_objs:
             del self.event_objs[name]
         if not keep_attached_events and "before_" + name in self.event_objs:

--- a/tests/features/modules/a/__init__.py
+++ b/tests/features/modules/a/__init__.py
@@ -4,8 +4,9 @@ def test():
 
 
 def main(event):
-    print(event.test.mf_modules)
-    print(event.test.fns)
+    event.test()
+    print(event._data["test"]["modules"])
+    print(event._data["test"]["raw_functions"])
     print(event["modules.a"])
     print(event.optional["modules.a"])
     print(event.optional.test())

--- a/tests/features/modules/b/__init__.py
+++ b/tests/features/modules/b/__init__.py
@@ -4,8 +4,9 @@ def test():
 
 
 def main(event):
-    print(event.test.mf_modules)
-    print(event.test.fns)
+    event.test()
+    print(event._data["test"]["modules"])
+    print(event._data["test"]["raw_functions"])
     print(event["modules.a"])
     print(event.optional["modules.a"])
 


### PR DESCRIPTION
#Replaced attached properties with hidden database 
**Attention**: This is a breaking change.

This MR changes the way miniflask saves data that relates to the wrapped event functions.

**Previously**:
- Wrapped events (functions or classes) were decorated with attributes that specify how the callables are used to construct the actual events
- Especially, when using classes this may lead to unexpected behavior 

To solve this, the `event` object now contains a hidden `_data` dictionary that saves this information.
**New Behavior**:
- `event._data[eventname]` contains the dictionary with all information required to construct the events
- `event._data[eventname]["modules"]`: list of modules that define the event `eventname`
- `event._data[eventname]["wrapped_event"]`: symlink to `event.eventname`
- `event._data[eventname]["wrapped_single_events"]`: list of all wrapped events in case of non-unique event `eventname`
- `event._data[eventname]["raw_functions"]`: list of all raw functions (as defined in code) in the modules given above (same order as in the modules list)
- `event._data[eventname]["raw_function_args"]`: the `mf`, `state` and `event` objects arguments needed for the raw functions


**Check all before creating this PR**:
- [x] Documentation adapted
- [x] unit tests adapted / created

