### PR TITLE
Predefined error messages

### DIFF
--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -693,6 +693,8 @@ class miniflask():
             Setting to `False` disables function parsing if the value is a method itself. Doing so may be required if the value to be saved is a function itself. By default miniflask will call function values to set the value dynamically as part of the variable dependency chain.
         - `caller_traceback`:  
             The traceback to use when an error occurs during registration of any of the listed variables. (Defaults to current traceback).
+        - `missing_argument_message`:  
+            String to show the user whenever one of the given (and required) arguments are not present after CLI-parsing.
 
         Examples:
         ```python

--- a/tests/argparse/required/modules/module1_with_error_message/__init__.py
+++ b/tests/argparse/required/modules/module1_with_error_message/__init__.py
@@ -1,0 +1,55 @@
+from enum import Enum
+
+
+class SIZE(Enum):
+    SMALL = 0
+    MEDIUM = 1
+    LARGE = 2
+
+
+def printVal(state, name):
+    val = state[name]
+    print("%s:" % state.fuzzy_names[name], val)
+
+
+def print_all(state):
+    printVal(state, "int1")
+    printVal(state, "int2")
+    printVal(state, "float1")
+    printVal(state, "float2")
+    printVal(state, "float3")
+    printVal(state, "float4")
+    printVal(state, "float5")
+    printVal(state, "float6")
+    printVal(state, "bool1")
+    printVal(state, "bool2")
+    printVal(state, "enum1")
+    printVal(state, "str1")
+    printVal(state, "str2")
+    printVal(state, "str3")
+
+
+def print_bool(state):
+    printVal(state, "bool1")
+    printVal(state, "bool2")
+
+
+def register(mf):
+    mf.register_defaults({
+        "int1": int,
+        "int2": int,
+        "float1": float,
+        "float2": float,
+        "float3": float,
+        "float4": float,
+        "float5": float,
+        "float6": float,
+        "bool1": bool,
+        "bool2": bool,
+        "enum1": SIZE,
+        "str1": str,
+        "str2": str,
+        "str3": str,
+    }, missing_argument_message="Did you forget something?")
+    mf.register_event('print_all', print_all, unique=False)
+    mf.register_event('print_bool', print_bool, unique=False)

--- a/tests/argparse/required/test_argparse_required_with_error_message.py
+++ b/tests/argparse/required/test_argparse_required_with_error_message.py
@@ -1,0 +1,66 @@
+import re
+from pathlib import Path
+import miniflask  # noqa: E402
+
+mf = miniflask.init(
+    module_dirs=str(Path(__file__).parent / "modules"),
+    debug=True
+)
+
+
+def escape_ansi(line):
+    ansi_escape = re.compile(r'(?:\x1B[@-_]|[\x80-\x9F])[0-?]*[ -/]*[@-~]')
+    return ansi_escape.sub('', line)
+
+
+def test_types():
+    mf.load("module1_with_error_message")
+    error_message = """
+    Missing CLI-arguments or unspecified variables during miniflask call.
+        --modules.module1_with_error_message.int1
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.int2
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.float1
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.float2
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.float3
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.float4
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.float5
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.float6
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.bool1
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.bool2
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.enum1
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.str1
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.str2
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+        --modules.module1_with_error_message.str3
+        Defined in line 38 in file 'modules/module1_with_error_message/__init__.py'.
+
+Did you forget something?
+""".strip().split("\n")
+    try:
+        mf.parse_args(argv=[])
+    except ValueError as excinfo:
+        errtext = escape_ansi(str(excinfo)).split("\n")
+
+    assert len(error_message) == len(errtext)
+    for expected, error in zip(error_message, errtext):
+
+        # we ignore the folder from which pytest is run
+        # (this would change the relative file path of the error message)
+        if "'" in expected:
+            start, end = expected.strip().split("'", 1)
+            assert error.strip().startswith(start)
+            assert error.strip().endswith(end)
+        else:
+            assert error.strip() == expected.strip(), (error, expected)


### PR DESCRIPTION
# Add Error Message to Required Variables

This MR allows the module-creator to give the user more information about a set of required variables (if they are missing).

## Description
Reason for this change is that miniflask allows module-groups to be entangled, in a way that require a module of one group to be loaded in order for another module to be working.
For instance, imagine a module to be a template or base-class for other instanciations that set the base variables according to their specialized features.

This MR gives the possibility to remind the user in such cases that there is such an dependency and the user requires to choose a specialization.

**Previously**:
The user would get a list of all required parameters, possibly not remembering or knowing about the inter-connection of some modules.

**New Behavior**:
Additionally, the user gets a message to describe the unmet dependencies.


## Things done in this MR
- added an option to `mf.register_defaults(..., missing_argument_message=None)`

**Check all before creating this PR**:
- [x] Documentation adapted
- [x] unit tests adapted / created


## Example Usage

```python
def register(mf):
    mf.register_default({'somevariable', int}, missing_argument_message="Did you forget to load a module to specialize this base-module?")
```
