### PR TITLE
Bugfix optional list type

### DIFF
--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -1296,7 +1296,8 @@ class miniflask_wrapper(miniflask):
         Define optional variables.
 
         # Note {.alert}
-        Optional variables are `None` if unspecified by the user.
+        - Optional variables are `None` if unspecified by the user.
+        - Exception are optional list types. These return `[]` if unspecified by the user.
 
         Args:
         - `variable_type`: The type to ask the user for in cli.
@@ -1305,6 +1306,7 @@ class miniflask_wrapper(miniflask):
         ```python
         mf.register_defaults({
             "myvar": mf.optional(int)
+            "myvarlist": mf.optional([int])
         })
         ```
         """  # noqa: W291

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -771,7 +771,7 @@ class miniflask():
                 else:
                     val_type, start_del, end_del = "tuple", "(", ",)"
                 raise RegisterError(f"Variable '%s' is registered as {val_type} of length 0 (see exception below), however it is required to define the type of the {val_type} arguments for it to become accessible from cli.\n\nYour options are:\n\t- define a default {val_type}, e.g. {start_del}\"a\", \"b\", \"c\"{end_del}\n\t- define the {val_type} type, e.g. {start_del}str{end_del}\n\t- define the variable as a helper using register_helpers(...)" % (fg('red') + varname + attr('reset')), traceback=caller_traceback)
-            self._settings_parser_add(varname, val[0], caller_traceback, nargs="*" if isinstance(val, list) else len(val), default=val)
+            self._settings_parser_add(varname, val[0], caller_traceback, nargs="*" if isinstance(val, list) else len(val), default=val, is_optional=is_optional)
             return
 
         # get argument type from value (this can be int, but also 42 for instance)
@@ -788,7 +788,7 @@ class miniflask():
         # we know the default argument, if the value is given
         # otherwise the value is a required argument (to be tested later)
         if is_optional:
-            kwarg["default"] = None
+            kwarg["default"] = None if nargs is None else []
         elif not isinstance(val, type) and not isinstance(val, EnumMeta):
             kwarg["default"] = default if default is not None else val
         else:
@@ -934,9 +934,6 @@ class miniflask():
 
             for varname, (val, cliargs, parsefn, caller_traceback, _mf) in settings.items():
                 is_fn = callable(val) and not isinstance(val, type) and not isinstance(val, EnumMeta) and parsefn
-
-                # if isinstance(val, optional_default):
-                #     breakpoint()
 
                 # eval dependencies/like expressions
                 if is_fn:

--- a/tests/argparse/optional/modules/module1/__init__.py
+++ b/tests/argparse/optional/modules/module1/__init__.py
@@ -25,6 +25,7 @@ def print_all(state):
     printVal(state, "bool1")
     printVal(state, "bool2")
     printVal(state, "enum1")
+    printVal(state, "enum2")
     printVal(state, "str1")
     printVal(state, "str2")
     printVal(state, "str3")
@@ -38,18 +39,19 @@ def print_bool(state):
 def register(mf):
     mf.register_defaults({
         "int1": optional(int),
-        "int2": optional(int),
+        "int2": optional([int]),
         "float1": optional(float),
         "float2": optional(float),
         "float3": optional(float),
         "float4": optional(float),
         "float5": optional(float),
-        "float6": optional(float),
+        "float6": optional([float]),
         "bool1": optional(bool),
-        "bool2": optional(bool),
+        "bool2": optional([bool]),
         "enum1": optional(SIZE),
+        "enum2": optional([SIZE]),
         "str1": optional(str),
-        "str2": optional(str),
+        "str2": optional([str]),
         "str3": optional(str),
     })
     mf.register_event('print_all', print_all, unique=False)

--- a/tests/argparse/optional/test_argparse_optional_types.py
+++ b/tests/argparse/optional/test_argparse_optional_types.py
@@ -17,18 +17,19 @@ def test_none(capsys):
     captured = capsys.readouterr()
     assert captured.out == """
 modules.module1.int1: None
-modules.module1.int2: None
+modules.module1.int2: []
 modules.module1.float1: None
 modules.module1.float2: None
 modules.module1.float3: None
 modules.module1.float4: None
 modules.module1.float5: None
-modules.module1.float6: None
+modules.module1.float6: []
 modules.module1.bool1: None
-modules.module1.bool2: None
+modules.module1.bool2: []
 modules.module1.enum1: None
+modules.module1.enum2: []
 modules.module1.str1: None
-modules.module1.str2: None
+modules.module1.str2: []
 modules.module1.str3: None\n""".lstrip()
 
 
@@ -51,6 +52,7 @@ def test_space(capsys):
         "--bool1", "False",
         "--bool2", "True",
         "--enum1", "small",
+        "--enum2", "medium",
         "--str1", "abcd1234",
         "--str2", "αβγδ∀⇐Γ∂",
         "--str3", ""
@@ -61,18 +63,19 @@ def test_space(capsys):
     captured = capsys.readouterr()
     assert captured.out == """
 modules.module1.int1: 1337
-modules.module1.int2: -1337
+modules.module1.int2: [-1337]
 modules.module1.float1: 1.234
 modules.module1.float2: -1.234
 modules.module1.float3: -0.0
 modules.module1.float4: 0.0
 modules.module1.float5: 300000.0
-modules.module1.float6: -300000.0
+modules.module1.float6: [-300000.0]
 modules.module1.bool1: False
-modules.module1.bool2: True
+modules.module1.bool2: [True]
 modules.module1.enum1: SIZE.SMALL
+modules.module1.enum2: [<SIZE.MEDIUM: 1>]
 modules.module1.str1: abcd1234
-modules.module1.str2: αβγδ∀⇐Γ∂
+modules.module1.str2: ['αβγδ∀⇐Γ∂']
 modules.module1.str3: \n""".lstrip()
 
 
@@ -95,6 +98,7 @@ def test_equal(capsys):
         "--bool1=False",
         "--bool2=True",
         "--enum1=small",
+        "--enum2=medium",
         "--str1=abcd1234",
         "--str2=αβγδ∀⇐Γ∂",
         "--str3="
@@ -105,16 +109,17 @@ def test_equal(capsys):
     captured = capsys.readouterr()
     assert captured.out == """
 modules.module1.int1: 1337
-modules.module1.int2: -1337
+modules.module1.int2: [-1337]
 modules.module1.float1: 1.234
 modules.module1.float2: -1.234
 modules.module1.float3: -0.0
 modules.module1.float4: 0.0
 modules.module1.float5: 300000.0
-modules.module1.float6: -300000.0
+modules.module1.float6: [-300000.0]
 modules.module1.bool1: False
-modules.module1.bool2: True
+modules.module1.bool2: [True]
 modules.module1.enum1: SIZE.SMALL
+modules.module1.enum2: [<SIZE.MEDIUM: 1>]
 modules.module1.str1: abcd1234
-modules.module1.str2: αβγδ∀⇐Γ∂
+modules.module1.str2: ['αβγδ∀⇐Γ∂']
 modules.module1.str3: \n""".lstrip()


### PR DESCRIPTION
# Bugfix: `mf.optional` for list types

This MR enables (or fixes `mf.optional` for) list types.

## Description
Miniflask did not allow to specify empty CLI-lists previously.
Using `mf.optional` this is now possible.

Not specifying the variable in CLI results in an empty list.


**Check all before creating this PR**:
- [x] Documentation adapted
- [x] unit tests adapted / created


## Example Usage
```python
def register(mf):
    mf.register_defaults({
       "variablelist": mf.optional([int])
    })
```
