### PR TITLE
event: added method event.exists(event_name)

### DIFF
--- a/src/miniflask/event.py
+++ b/src/miniflask/event.py
@@ -421,6 +421,22 @@ class event(dict):
             results = [results]
         return dict(zip(self._data[event_name]["modules"], results))
 
+    def exists(self, event_name):
+        r"""
+        Check if an event has been registered.
+
+        Args:
+        - `event_name`: (required)  
+            Eventname to check.
+
+        Examples:
+        ```python
+        if event.exists('to_be_called'):
+            event.to_be_called()
+        ```
+        """  # noqa: W291
+        return event_name in self._mf.event_objs
+
     # disables deepcopy(event), as it is tightly bounded to other miniflask objects
     def __deepcopy__(self, memo):
         del memo

--- a/tests/event/register_event/test_event_exists.py
+++ b/tests/event/register_event/test_event_exists.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import miniflask  # noqa: E402
+
+
+def init_mf():
+    return miniflask.init(module_dirs=str(Path(__file__).parent / "modules"), debug=True)
+
+
+def test_event_exists_false():
+    mf = init_mf()
+    mf.run(argv=[], modules=[])
+    assert not mf.event.exists("main")
+    assert not mf.event.exists("add_test")
+    assert not mf.event.exists("sub_test")
+
+
+def test_event_exists_true():
+    mf = init_mf()
+    mf.run(argv=[], modules=["register_event_during_event"])
+    assert mf.event.exists("main")
+    assert mf.event.exists("add_test")
+    assert not mf.event.exists("sub_test")


### PR DESCRIPTION
# `event.exists(event_name)`

**Attention**: Using the event with the name `exists` is not possible anymore with this MR.

This MR adds the function `event.exists(event_name)` to each event object.

## Description
Instead of calling `event.optional.event_name` one might want to check if an event exists and proceed from there with different behavior.


**Check all before creating this PR**:
- [x] Documentation adapted
- [x] unit tests adapted / created


## Example Usage

**It can be used inside events as follows**:
```python
def some_event(event):
   if event.exists("other_event"):
       print("other_event exists")
```

**This can be also used for a more dynamic registration**:
```python
def register(mf):
   if mf.event.exists("some_event"):
      mf.register_event("some_event", lambda x: print("some_event called"))
```
