### PR TITLE
Bugfix: CLI argument without value (i.e. a boolean setting) raises Exception

### DIFF
--- a/src/miniflask/__init__.py
+++ b/src/miniflask/__init__.py
@@ -4,7 +4,7 @@ from .modules import *
 from .state import like, optional
 
 # meta
-__version__       = "4.0.1"
+__version__       = "4.0.2"
 __title__         = "miniflask"
 __description__   = "Small research-oriented hook-based plugin engine."
 __url__           = "https://github.com/da-h/miniflask"

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -1030,7 +1030,7 @@ class miniflask():
             namespaces[-1] = arg[2:]
 
             # skip argument if is just a namespace
-            if i < len_argv and argv[i + 1] == "[":
+            if i + 1 < len_argv and argv[i + 1] == "[":
                 continue
 
             # actual name is name with namespace

--- a/tests/argparse/values/test_argparse_overwrites.py
+++ b/tests/argparse/values/test_argparse_overwrites.py
@@ -173,3 +173,24 @@ def test_bool_truefalse(capsys):
 modules.module1.bool1: False
 modules.module1.bool2: True
 """.lstrip()
+
+
+def test_bool_novalue(capsys):
+    mf = miniflask.init(
+        module_dirs=str(Path(__file__).parent / "modules"),
+        debug=True
+    )
+
+    mf.load("module1")
+    mf.parse_args([
+        "--no-bool1",
+        "--bool2",
+    ])
+    captured = capsys.readouterr()
+
+    mf.event.print_bool()
+    captured = capsys.readouterr()
+    assert captured.out == """
+modules.module1.bool1: False
+modules.module1.bool2: True
+""".lstrip()


### PR DESCRIPTION
# Bugfix: CLI argument without value (i.e. a boolean setting) raises Exception

This MR fixes an error due to a recent change in miniflask `v4.0`, given in MR #96.

## Description
The bug was that no boolean setting could be set anymore using the notation `--boolsetting`.

This MR fixes this issue and includes the missing unit test that should test against this kind of use.

**Check all before creating this PR**:
- [x] unit tests adapted / created