### PR TITLE
Improve print order of state variables in settings module.

### DIFF
--- a/src/miniflask/modules/settings/__init__.py
+++ b/src/miniflask/modules/settings/__init__.py
@@ -24,20 +24,23 @@ def listsettings(mf, state, asciicodes=True):
     linesep = os.linesep if asciicodes else "\n"
     attr_fn = (lambda x: '') if not asciicodes else attr
 
+    text_list = []
     last_k = []
     if len(state.all) == 0:
         return "No Settings available."
-    maxklen = max(len(k) for k in state.all.keys())
-    text = "Folder│" + color_name("module") + "│" + color_module("variable") + (" " * (maxklen - 22)) + " = " + color_val("value") + linesep
-    text += "—" * (maxklen + 8) + linesep if asciicodes else ''
+    max_k_len = max(len(k) for k in state.all.keys())
+
+    preamble_text = "Folder│" + color_name("module") + "│" + color_module("variable") + (" " * (max_k_len - 22)) + " = " + color_val("value") + linesep
+    preamble_text += "—" * (max_k_len + 8) + linesep if asciicodes else ''
+
     for k, v in sorted(state.all.items()):
 
         # ignore state variables that are not registered for argument parsing
         if k not in state.default:
             continue
 
-        klen = len(k)
-        korig = k
+        k_len = len(k)
+        k_orig = k
         overwritten = v != (state.default[k].default if hasattr(state.default[k], 'default') else state.default[k])
         k = k.split(".")
         if len(k) > 1:
@@ -49,20 +52,20 @@ def listsettings(mf, state, asciicodes=True):
             k_hidden = k
             k_hidden[-1] = color_module(k_hidden[-1])
 
-        is_lambda = callable(state.default[korig]) and not isinstance(state.default[korig], type) and not isinstance(state.default[korig], EnumMeta) and not isinstance(state.default[korig], like)
-        value_str = attr_fn('dim') + "λ ⟶   " + attr_fn('reset') + str(state.default[korig].default) if is_lambda else state.default[korig].str(asciicodes=False) if hasattr(state.default[korig], 'str') else str(state.default[korig])
+        is_lambda = callable(state.default[k_orig]) and not isinstance(state.default[k_orig], type) and not isinstance(state.default[k_orig], EnumMeta) and not isinstance(state.default[k_orig], like)
+        value_str = attr_fn('dim') + "λ ⟶   " + attr_fn('reset') + str(state.default[k_orig].default) if is_lambda else state.default[k_orig].str(asciicodes=False) if hasattr(state.default[k_orig], 'str') else str(state.default[k_orig])
         append = "" if not overwritten else " ⟶   " + color_val_overwrite(str(v))
-        text += "│".join(k_hidden) + (" " * (maxklen - klen)) + " = " + color_val(value_str) + append + linesep
+        text_list.append("│".join(k_hidden) + (" " * (max_k_len - k_len)) + " = " + color_val(value_str) + append)
 
         # add definition paths
         if state["show_registration_definitions"]:
-            prefix = "│".join([" " * len(k) for k in korig.split(".")]) + (" " * (maxklen - klen)) + "   "
-            for definition_type, caller_traceback in mf._settings_parser_tracebacks[korig]:
+            prefix = "│".join([" " * len(k) for k in k_orig.split(".")]) + (" " * (max_k_len - k_len)) + "   "
+            for definition_type, caller_traceback in mf._settings_parser_tracebacks[k_orig]:
                 summary = next(filter(lambda t: not t.filename.endswith("miniflask/miniflask.py"), reversed(caller_traceback)))
                 arg_err_str = (fg('blue') + "definition" if definition_type == "definition" else fg('yellow') + "overwritten") + attr('reset') + " in line %s in file '%s'." % (highlight_event(str(summary.lineno)), attr('dim') + os.path.relpath(summary.filename) + attr('reset'))
-                text += prefix + arg_err_str + linesep
+                text_list.append(prefix + arg_err_str)
 
-    return text
+    return preamble_text + linesep.join(text_list)
 
 
 def init(mf, state):

--- a/src/miniflask/modules/settings/__init__.py
+++ b/src/miniflask/modules/settings/__init__.py
@@ -32,9 +32,9 @@ def sorted_by_state_key_modules(items):
     modules = deque([module_tree])
     while modules:
         mod = modules.pop()
-        for m in sorted(mod["modules"], reverse=True):
+        for m in sorted(mod["modules"], reverse=True, key=str.lower):
             modules.append(mod["modules"][m])
-        for e in sorted(mod["params"]):
+        for e in sorted(mod["params"], key=lambda tup: str.lower(tup[0])):
             yield e
 
 

--- a/src/miniflask/modules/settings/__init__.py
+++ b/src/miniflask/modules/settings/__init__.py
@@ -21,11 +21,8 @@ def sorted_by_state_key_modules(items):
     module_tree_template = {"modules": {}, "params": []}
     module_tree = copy.deepcopy(module_tree_template)
     for k, v in items:
-        _splits = k.split('.')
-        _modules = _splits[:-1]
-        _param = _splits[-1]
         leaf = module_tree
-        for mod in _modules:
+        for mod in k.split('.')[:-1]:
             _leaf = leaf["modules"].get(mod, copy.deepcopy(module_tree_template))
             if mod not in leaf:
                 leaf["modules"][mod] = _leaf


### PR DESCRIPTION
# Improve print order of state variables in settings module

This MR sorts state variables based on their (nested) module name in case-insensitive, alphabetical order, with parameters always on top.

## Description

**Setup**:
Use settings module to print state variables.

**Problem**:
Some variables were hard to find between nested modules.

**Previously**:
Note the `**` and `<--`, which are variables of different modules, which are not printed as a group.
```
d           = ...  **
sa│Aa│a     = ...
  │  │b     = ...
  │Ab       = ...  <--
  │D        = ...  <--
  │L│a      = ...
  │ │b      = ...
  │M        = ...  <--
  │Sa│a     = ...
  │  │ba    = ...
  │  │bb│ta = ...
  │  │  │tb = ...
  │Sb       = ...  <--
  │Sca│a    = ...
  │   │b    = ...
  │Scb│a    = ...
  │   │b    = ...
  │Ta       = ...  <--
  │Tb│m     = ...
  │ │n      = ...
  │a        = ...  <--
sb          = ...  **
v           = ...  **
```

**New Behavior**:
```
d           = ...  **
sb          = ...  **
v           = ...  **
sa│a        = ...  <--
  │Ab       = ...  <--
  │D        = ...  <--
  │M        = ...  <--
  │Sb       = ...  <--
  │Ta       = ...  <--
sa│Aa│a     = ...
  │  │b     = ...
  │L│a      = ...
  │ │b      = ...
  │Sa│a     = ...
  │  │ba    = ...
  │  │bb│ta = ...
  │  │  │tb = ...
  │Sca│a    = ...
  │   │b    = ...
  │Scb│a    = ...
  │   │b    = ...
  │Tb│m     = ...
  │ │n      = ...
```


## Things done in this MR
- Create tree of state variables, sorts parameters and modules separately, and first list parameters, then sorted modules.

**Check all before creating this PR**:
- [ ] Documentation adapted
- [ ] unit tests adapted / created


## Example Usage
Use the settings module to list state variables.
