### PR TITLE
mf.as_is_callable

### DIFF
--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -376,6 +376,11 @@ class like:
         return self.str()
 
 
+class as_is_callable():  # pylint: disable=too-few-public-methods
+    def __init__(self, obj):
+        self.obj = obj
+
+
 class optional:
     def __init__(self, variable_type):
         self.type = variable_type


### PR DESCRIPTION
# `mf.as_is_callable`

When defining default variables during `register()`, i.e. using `register_helpers`, it is possible to specify if callables are parsed to resolve variable chains using `register_helpers({...}, parsefn=False)`.

This MR adds a small QoL-Alias to include the same functionality into the variable definition itself, i.e.
instead splitting into two calls:
```
mf.register_helpers({
   "var": lambda x: 42
})
mf.register_helpers({
   "instance": MyClass()
}, parsefn=False)
```
this feature allows to merge such calls into a single one:
```
mf.register_helpers({
   "var": lambda x: 42
   "instance": mf.as_is_callable(MyClass())
})
```
