### PR TITLE
linter: fix errors by removing 'no-self-use'

### DIFF
--- a/.github/workflows/linting-python.yml
+++ b/.github/workflows/linting-python.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Static Analysis
       run: |
         flake8 src --count --ignore E501 --statistics
-        pylint -d W0511 -d C0114 -d C0116 -d C0115 -d C0301 -d C0302 -d C0303 -d C0103 -d C0209 -d R0913 -d R0914 -d R0902 -d R0912 -d R0801 -d R1702 -d W0212 -d W0223 -d E1101 -d W0221 -d E1102 src/miniflask
+        pylint -d W0511 -d C0114 -d C0116 -d C0115 -d C0301 -d C0302 -d C0303 -d C0103 -d C0209 -d C3001 -d R0913 -d R0914 -d R0902 -d R0912 -d R0801 -d R1702 -d W0212 -d W0223 -d E1101 -d W0221 -d E1102 src/miniflask
         pylint --exit-zero src/miniflask
     - name: Syntax Check of Tests
       run: |
@@ -37,5 +37,5 @@ jobs:
     - name: Static Analysis of Tests (Modules)
       run: |
         flake8 tests --count --ignore E501 --statistics
-        pylint -d W0511 -d C0114 -d C0116 -d C0115 -d C0301 -d C0302 -d C0303 -d C0103 -d C0209 -d R0913 -d R0914 -d R0902 -d R0912 -d R0801 -d W0212 -d W0223 -d E1101 -d W0221 -d E1102 `find tests -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`
+        pylint -d W0511 -d C0114 -d C0116 -d C0115 -d C0301 -d C0302 -d C0303 -d C0103 -d C0209 -d C3001 -d R0913 -d R0914 -d R0902 -d R0912 -d R0801 -d W0212 -d W0223 -d E1101 -d W0221 -d E1102 `find tests -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`
         pylint --exit-zero `find tests -type f -name '.module' -printf '%h\0' | sort -zu | sed -z 's/$/\n/'`

--- a/src/miniflask/event.py
+++ b/src/miniflask/event.py
@@ -443,7 +443,7 @@ class event(dict):
         del memo
         return self
 
-    def outervar(self):  # pylint: disable=no-self-use
+    def outervar(self):
         r"""!outervar
         For debbuging mainly: Changing the variables an event is called with.
 

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -1310,7 +1310,7 @@ class miniflask_wrapper(miniflask):
         return new_module_name
 
     # wrapper for the optional class
-    def optional(self, variable_type):  # pylint: disable=no-self-use
+    def optional(self, variable_type):
         r"""
         Define optional variables.
 


### PR DESCRIPTION
# Linter Error Fixes
This MR fixes two small linter errors due to newer versions.