### PR TITLE
Update autotag action usage.

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: '16'
       - name: Autoadd release Tags
-        uses: jaliborc/action-general-autotag@1.0.1
+        uses: sbrodehl/action-autotag@v2.0.0
         id:   autotag
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR update the usage of the autotag action by switching to another version which is maintained.
