### PR TITLE
Bugfixes for new mf.as_is_callable feature

### DIFF
--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -754,7 +754,7 @@ class miniflask():
 
             # overwrite parsefn for as_is_callable object
             if isinstance(val, as_is_callable):
-                parsefn = True
+                parsefn = False
 
             # actual initialization is done when all modules has been parsed
             if overwrite:

--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -380,6 +380,9 @@ class as_is_callable():  # pylint: disable=too-few-public-methods
     def __init__(self, obj):
         self.obj = obj
 
+    def __call__(self, *args, **kwargs):
+        return self.obj(*args, **kwargs)
+
 
 class optional:
     def __init__(self, variable_type):


### PR DESCRIPTION

## Description
`mf.as_is_callable` have been introduced in #107.
Its goal is to allow helper variables to be set to classes.
By default, callable variables are expected to be dependency-functions that are called in the initialization phase of miniflask unless specified using `parsefn=False`.

This MR
- allows these callable variables defined using `mf.as_is_callable` to be used/called just as the class-instance it wraps
- by default sets `parsefn` to `False`. This effectively disables searching for dependency-chains for those classes, as this was the whole motivitaion for `mf.as_is_callable`

