### PR TITLE
re-enable automatic github releases

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -25,6 +25,15 @@ jobs:
           capture_group: 1
           tag_message: "Release"
           tag_format: "v{version}"
+      - name: Create Release
+        if: steps.autotag.outputs.tagsha
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.autotag.outputs.tagname }}
+          release_name: "Miniflask ${{ steps.autotag.outputs.tagname }}"
       - name: Show version
         if: steps.autotag.outputs.tagsha
         run: echo ${{ steps.autotg.outputs.tagsha }}


### PR DESCRIPTION
# Re-Enable automatic github releases
Until `v4.0.2` github releases have been triggered automatically.
As something in the toolchain has chaned since then, this MR readds this functionality using the official github action `actions/create-release`.
