### PR TITLE
Use direct import if possible, otherwise use legacy import.

### DIFF
--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -179,9 +179,13 @@ class miniflask():
         if importpath == "system":
             return import_module(module_spec["importname"])
 
-        direct_import = import_module(module_spec["importname"])
-        if direct_import:
-            return direct_import
+        try:
+            direct_import = import_module(module_spec["importname"])
+            if direct_import:
+                return direct_import
+        except ModuleNotFoundError:
+            pass
+
         # imports across filesystem
         # the random id (_instance_id) ensures sys.modules does not cache different miniflask instances
         # (first we need to load the parent module, if available)

--- a/src/miniflask/miniflask.py
+++ b/src/miniflask/miniflask.py
@@ -179,6 +179,9 @@ class miniflask():
         if importpath == "system":
             return import_module(module_spec["importname"])
 
+        direct_import = import_module(module_spec["importname"])
+        if direct_import:
+            return direct_import
         # imports across filesystem
         # the random id (_instance_id) ensures sys.modules does not cache different miniflask instances
         # (first we need to load the parent module, if available)


### PR DESCRIPTION
This PR tries to import modules directly with the given module name/path if possible (assuming the module is a regular python module in the project).

Otherwise, the legacy code is run.

## Description

**Problem**:
Previously, serializing code, where miniflask modules are used, resulted in errors, since the import paths and names of the modules are changed (randomly).

**New Behavior**:
Now, if mf modules are actual python modules, a direct import is used.


**Check all before creating this PR**:
- [ ] Documentation adapted
- [ ] unit tests adapted / created