### PR TITLE
github: fix warning from pypi action

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -47,7 +47,7 @@ jobs:
         run: python setup.py sdist
       - name: Publish a Python distribution to PyPI
         if: steps.autotag.outputs.tagsha
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
             user: __token__
             password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
# Fix Warning from PyPI Action

Just a tiny PR: the github action for publishing to PyPI asks for fixing the action-branch to anything other than `master`.

Here, the `release/v1`-branch has been chosen.
