### PR TITLE
github: fix wrong auto-tag name

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ steps.autotag.outputs.tagname }}
+          tag_name: ${{ steps.autotag.outputs.tagname }}
           release_name: "Miniflask ${{ steps.autotag.outputs.tagname }}"
       - name: Show version
         if: steps.autotag.outputs.tagsha


### PR DESCRIPTION
# Github Action: fix wrong auto-tag name

This MR fixes the duplicate `v` in front of tag names.
