### PR TITLE
tests: add test against illegal-annotation bug

### DIFF
--- a/tests/state/dependencies/modules/defarguments_module1/__init__.py
+++ b/tests/state/dependencies/modules/defarguments_module1/__init__.py
@@ -40,4 +40,6 @@ def register(mf):
         "var4": var4_fn,
         "var5": var5_fn,
         "var6": var6_fn,
+        "annotation": lambda: 10,
+        "annotation.bug": lambda: 10
     })


### PR DESCRIPTION
This PR adds a failing test case to the `v5-dev` branch.

The issue is that the registration method
```python
def register(mf):
    mf.register_defaults({
        "annotation": lambda: 10,
        "annotation.bug": lambda: 10
    })
```
succeeds for the first line registering `state["annotation"]`, but **fails for the second line registering `state["annotation.bug"]`.


**Merging this failing test because any further development of `v5` should fix this issue first.**