### PR TITLE
state: improve lambda regex, allowing any key name

### DIFF
--- a/src/miniflask/state.py
+++ b/src/miniflask/state.py
@@ -383,7 +383,7 @@ class optional:
 
 class state_node:
 
-    _lambda_str_regex = re.compile(r"^{?\s*\"\w*\"\s*:\s*lambda\s*\w*:.*}?")
+    _lambda_str_regex = re.compile(r"^{?\s*(\"[^\"]*\")|('[^']*')\s*:\s*lambda\s*\w*:.*}?")
     local_arguments = []
     depends_on = []
     depends_alternatives = []


### PR DESCRIPTION
# FEATURENAME

This MR fixes the failing test introduced in #123.

## Description

**Problem**
was that the regex did not match any string, but only keys consisting of proper words (i.e. `"anyword"`).

**New Behavior**:
the new string-regex allows any string using `"[^"]*"` syntax instead. Also, this PR adds the possibility to use single quotation marks for the keys.

