### PR TITLE
Move actions/create-release to softprops/action-gh-release

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -28,12 +28,11 @@ jobs:
       - name: Create Release
         if: steps.autotag.outputs.tagsha
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: v${{ steps.autotag.outputs.tagname }}
           release_name: "Miniflask ${{ steps.autotag.outputs.tagname }}"
+          generate_release_notes: true
       - name: Show version
         if: steps.autotag.outputs.tagsha
         run: echo ${{ steps.autotg.outputs.tagsha }}


### PR DESCRIPTION
# FEATURENAME


## Description

Until now, this project uses githubs own action for creating new releases named `action/create-release`.
However, the [action is currently unmaintained, and the developers suggest using an alternative in the README.md](https://github.com/actions/create-release).

This PR also enables automatically generated release notes containing PRs and commits added in the respective release since the last one.
(Currently, one must click a button on the release page to generate the messages).



